### PR TITLE
chore(deps): bump Scriban 6.6.0 -> 7.1.0 (closes #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Bumped Scriban 6.6.0 → 7.1.0** to clear three NuGet advisories that were promoted to hard build errors by `TreatWarningsAsErrors=true`:
+  - `GHSA-5wr9-m6jw-xx44` (critical) — sandbox bypass via cached `MemberFilter`
+  - `GHSA-m2p3-hwv5-xpqw` (moderate) — `LimitToString` denial of service
+  - `GHSA-xw6w-9jjh-p9cr` (moderate) — unbounded string multiplication / BigInteger shift denial of service
+  - Practical exposure was nil — Scriban is only used at build time by `PptMcp.Build.Tasks` to render source-controlled skill prompt templates, never with attacker-supplied input. The bump unblocks the McpServer build and clears the advisories. Scriban API surface used by `GenerateSkillFile` is stable across 6 → 7; no code changes were required.
+
 ### Added
 
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <!-- Template Engine for Skill Generation -->
-    <PackageVersion Include="Scriban" Version="6.6.0" />
+    <PackageVersion Include="Scriban" Version="7.1.0" />
     <!-- MSBuild Task Development -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />


### PR DESCRIPTION
## Summary

Bumps **Scriban from 6.6.0 → 7.1.0** to clear three NuGet advisories that are promoted to hard build errors by `TreatWarningsAsErrors=true`, blocking the McpServer build.

## Why

| Advisory | Severity | Description |
|---|---|---|
| [GHSA-5wr9-m6jw-xx44](https://github.com/advisories/GHSA-5wr9-m6jw-xx44) | **Critical** | Sandbox bypass via cached `MemberFilter` |
| [GHSA-m2p3-hwv5-xpqw](https://github.com/advisories/GHSA-m2p3-hwv5-xpqw) | Moderate | `LimitToString` denial of service |
| [GHSA-xw6w-9jjh-p9cr](https://github.com/advisories/GHSA-xw6w-9jjh-p9cr) | Moderate | Unbounded string mul / BigInteger shift DoS |

Build fails with:
```
error NU1902: Package 'Scriban' 6.6.0 has a known moderate severity vulnerability
error NU1904: Package 'Scriban' 6.6.0 has a known critical severity vulnerability
```

**Practical exposure was nil.** Scriban is only used at build time by `PptMcp.Build.Tasks/GenerateSkillFile.cs` to render source-controlled skill prompt templates — there is no path for attacker-supplied template text. The advisories matter here only because they block CI.

## Why 7.1.0

There is no Scriban 6.7.x — the project jumped from 6.x to 7.x. 7.1.0 is the latest release.

API surface used by `GenerateSkillFile` (`Template.Parse`, `HasErrors`, `Messages`, `ScriptObject.Import(model, renamer:)`, `TemplateContext`, `PushGlobal`, `Render`) is stable across 6 → 7. **No source changes required.**

## Changes

- `Directory.Packages.props` — `Scriban` `6.6.0` → `7.1.0`
- `CHANGELOG.md` — new `### Security` entry under `[Unreleased]`

## Verification

- ✅ `dotnet build PptMcp.sln -c Debug` → **0 warnings, 0 errors** (was: 3 errors on McpServer)
- ✅ `GenerateSkillFile` build task ran successfully — generated `obj\Debug\net9.0-windows\PptSkillPrompts.g.cs from 5 skill files` — proves runtime API compatibility with the new version

## Related

Closes #87

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
