### PR TITLE
feat(shape): stable shape identity via id:N prefix in shapeName (closes #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Shape commands: stable shape identity via `id:N` prefix.** Every `shapeName` / `shapeNames` parameter on the `shape` tool now accepts either the literal `Shape.Name` (existing behavior) or the stable `Shape.Id` via an `id:<N>` prefix (e.g. `id:42`). Ids are returned by `shape(list)` and `shape(read)` and survive renames, copy/paste, and reordering — making them safe references for multi-turn agent workflows. Backwards-compatible: no signature changes; name-based lookups continue to work.
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture
 - Dedicated documentation for the evaluation framework and the archetype/reference pipeline
 - **33 PowerPoint MCP tools with 204 operations** for comprehensive PowerPoint automation via COM interop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Bumped Scriban 6.6.0 → 7.1.0** to clear three NuGet advisories that were promoted to hard build errors by `TreatWarningsAsErrors=true`:
+  - `GHSA-5wr9-m6jw-xx44` (critical) — sandbox bypass via cached `MemberFilter`
+  - `GHSA-m2p3-hwv5-xpqw` (moderate) — `LimitToString` denial of service
+  - `GHSA-xw6w-9jjh-p9cr` (moderate) — unbounded string multiplication / BigInteger shift denial of service
+  - Practical exposure was nil — Scriban is only used at build time by `PptMcp.Build.Tasks` to render source-controlled skill prompt templates, never with attacker-supplied input. The bump unblocks the McpServer build and clears the advisories. Scriban API surface used by `GenerateSkillFile` is stable across 6 → 7; no code changes were required.
+
 ### Added
 
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <!-- Template Engine for Skill Generation -->
-    <PackageVersion Include="Scriban" Version="6.6.0" />
+    <PackageVersion Include="Scriban" Version="7.1.0" />
     <!-- MSBuild Task Development -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />

--- a/src/PptMcp.Core/Commands/Shape/IShapeCommands.cs
+++ b/src/PptMcp.Core/Commands/Shape/IShapeCommands.cs
@@ -7,9 +7,24 @@ namespace PptMcp.Core.Commands.Shape;
 /// <summary>
 /// Shape management: list, read, create, move, resize, delete, z-order.
 /// </summary>
+/// <remarks>
+/// SHAPE REFERENCES (shapeName / shapeNames parameters):
+/// Every shape-targeting parameter accepts one of two reference styles:
+///   - Literal <c>Shape.Name</c>, e.g. <c>"Title 1"</c>, <c>"Rectangle 7"</c>.
+///   - Stable <c>Shape.Id</c> via the <c>id:&lt;N&gt;</c> prefix, e.g. <c>"id:42"</c>.
+/// Names are user-mutable and may collide after delete/re-add. Ids are assigned
+/// by PowerPoint at insertion time and stable for the lifetime of the shape —
+/// they survive renames, copy/paste, and reordering. Prefer Id-based references
+/// for any agent workflow that touches the same shape across multiple turns.
+/// Both <c>shape(list)</c> and <c>shape(read)</c> return the <c>ShapeId</c>
+/// you should use.
+/// </remarks>
 [ServiceCategory("shape")]
 [McpTool("shape", Title = "Shape Operations", Destructive = true, Category = "shapes",
     Description = "Create, move, resize, format, and manage shapes on slides. The primary building tool. "
+    + "SHAPE REFERENCES: shape_name / shape_names accept either the literal Shape.Name (e.g. 'Title 1') "
+    + "or the stable Shape.Id via 'id:<N>' prefix (e.g. 'id:42'). Ids survive renames and reordering — "
+    + "prefer them. Get ids from shape(list) / shape(read). "
     + "auto_shape_type (MsoAutoShapeType): 1=Rectangle, 5=Triangle, 9=Oval, 10=Hexagon, 13=Pentagon, "
     + "16=Cube, 23=RoundedRectangle, 55=Chevron, 61=RightArrow, 92=Heart, 106=Plus, 127=Callout. "
     + "color_hex: '#RRGGBB' (e.g. '#0B3D91'). Use 'none' for transparent fill/line. "

--- a/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
+++ b/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
@@ -54,7 +54,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 return new ShapeDetailResult
@@ -131,7 +131,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 if (left.HasValue) shape.Left = left.Value;
@@ -162,7 +162,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 shape.Delete();
@@ -189,7 +189,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 shape.ZOrder(zOrderCmd);
@@ -217,7 +217,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 if (colorHex.Equals("none", StringComparison.OrdinalIgnoreCase))
@@ -255,7 +255,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 if (colorHex.Equals("none", StringComparison.OrdinalIgnoreCase))
@@ -292,7 +292,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 shape.Rotation = degrees;
@@ -327,7 +327,7 @@ public class ShapeCommands : IShapeCommands
                 dynamic? first = null;
                 try
                 {
-                    first = slide.Shapes.Item(names[0]);
+                    first = ShapeResolver.Resolve(slide, names[0]);
                     first.Select(true); // Replace=true to start new selection
                 }
                 finally
@@ -339,7 +339,7 @@ public class ShapeCommands : IShapeCommands
                     dynamic? s = null;
                     try
                     {
-                        s = slide.Shapes.Item(names[i]);
+                        s = ShapeResolver.Resolve(slide, names[i]);
                         s.Select(false); // Replace=false to add to selection
                     }
                     finally
@@ -386,7 +386,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 shape.Ungroup();
@@ -413,7 +413,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 shape.AlternativeText = altText;
@@ -441,7 +441,7 @@ public class ShapeCommands : IShapeCommands
         {
             dynamic pres = ctx.Presentation;
             dynamic srcSlide = pres.Slides.Item(slideIndex);
-            dynamic shape = srcSlide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(srcSlide, shapeName);
             try
             {
                 shape.Copy();
@@ -476,7 +476,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 dynamic shadow = shape.Shadow;
@@ -525,8 +525,8 @@ public class ShapeCommands : IShapeCommands
             dynamic? connector = null;
             try
             {
-                startShape = slide.Shapes.Item(startShapeName);
-                endShape = slide.Shapes.Item(endShapeName);
+                startShape = ShapeResolver.Resolve(slide, startShapeName);
+                endShape = ShapeResolver.Resolve(slide, endShapeName);
 
                 // AddConnector(Type, BeginX, BeginY, EndX, EndY)
                 // Type: 1=msoConnectorStraight, 2=msoConnectorElbow, 3=msoConnectorCurve
@@ -631,7 +631,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? dup = null;
             try
             {
@@ -665,7 +665,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 // msoFlipHorizontal=0, msoFlipVertical=1
@@ -694,7 +694,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? textFrame = null;
             try
             {
@@ -730,7 +730,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? fill = null;
             try
             {
@@ -786,7 +786,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? line = null;
             try
             {
@@ -850,7 +850,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 // TwoColorGradient(style, variant) - variant 1 is default direction
@@ -882,7 +882,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 dynamic glow = shape.Glow;
@@ -927,7 +927,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 dynamic reflection = shape.Reflection;
@@ -968,7 +968,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 // COM uses Transparency (0=opaque, 1=transparent), which is the inverse of opacity
@@ -1045,8 +1045,8 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic sourceShape = slide.Shapes.Item(sourceShapeName);
-            dynamic targetShape = slide.Shapes.Item(targetShapeName);
+            dynamic sourceShape = ShapeResolver.Resolve(slide, sourceShapeName);
+            dynamic targetShape = ShapeResolver.Resolve(slide, targetShapeName);
             try
             {
                 sourceShape.PickUp();
@@ -1079,7 +1079,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? actionSettings = null;
             dynamic? actionSetting = null;
             try
@@ -1138,7 +1138,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 // 0 = msoScaleFromTopLeft, relative to current size
@@ -1168,7 +1168,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             try
             {
                 // msoTrue = -1, msoFalse = 0
@@ -1199,7 +1199,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? softEdge = null;
             try
             {
@@ -1234,7 +1234,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? shadow = null;
             try
             {
@@ -1315,7 +1315,7 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic shape = ShapeResolver.Resolve(slide, shapeName);
             dynamic? threeD = null;
             try
             {

--- a/src/PptMcp.Core/Commands/Shape/ShapeResolver.cs
+++ b/src/PptMcp.Core/Commands/Shape/ShapeResolver.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+using PptMcp.ComInterop;
+
+namespace PptMcp.Core.Commands.Shape;
+
+/// <summary>
+/// Resolves a shape on a slide by either its mutable Name (the COM
+/// <c>Shape.Name</c> property) or by its stable Id via the <c>id:&lt;N&gt;</c>
+/// prefix syntax (matched against the COM <c>Shape.Id</c> property).
+/// </summary>
+/// <remarks>
+/// Centralising the lookup keeps every <see cref="ShapeCommands"/> action
+/// consistent: a single place owns the prefix parsing, the COM enumeration,
+/// and the descriptive not-found error.
+///
+/// <para>
+/// PowerPoint's <c>Shape.Id</c> is assigned on insertion and is stable for
+/// the lifetime of the shape. <c>Shape.Name</c> is user-mutable. Agents
+/// that store an Id reference (e.g. from <c>shape(list)</c> or
+/// <c>shape(read)</c>) can therefore safely target the same shape across
+/// renames, copy/paste, and arbitrary reordering.
+/// </para>
+/// </remarks>
+internal static class ShapeResolver
+{
+    private const string IdPrefix = "id:";
+
+    /// <summary>
+    /// Resolve a shape on the given slide. Returns the COM shape object
+    /// — caller is responsible for releasing it via
+    /// <see cref="ComUtilities.Release"/>.
+    /// </summary>
+    /// <param name="slide">The COM slide object that owns the shape.</param>
+    /// <param name="shapeNameOrId">
+    /// Either the literal <c>Shape.Name</c>, or <c>id:&lt;N&gt;</c> where
+    /// <c>N</c> is the integer <c>Shape.Id</c>.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="shapeNameOrId"/> uses the <c>id:</c>
+    /// prefix but the suffix is not a valid integer.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when an <c>id:&lt;N&gt;</c> reference does not match any
+    /// shape on the slide.
+    /// </exception>
+    public static dynamic Resolve(dynamic slide, string shapeNameOrId)
+    {
+        ArgumentNullException.ThrowIfNull(shapeNameOrId);
+
+        if (!TryParseId(shapeNameOrId, out int targetId))
+        {
+            // Existing behavior — let COM throw if the name is unknown.
+            return slide.Shapes.Item(shapeNameOrId);
+        }
+
+        dynamic? shapes = null;
+        try
+        {
+            shapes = slide.Shapes;
+            int count = (int)shapes.Count;
+            for (int i = 1; i <= count; i++)
+            {
+                dynamic candidate = shapes.Item(i);
+                bool match;
+                try
+                {
+                    match = (int)candidate.Id == targetId;
+                }
+                catch
+                {
+                    ComUtilities.Release(ref candidate!);
+                    throw;
+                }
+
+                if (match)
+                {
+                    return candidate;
+                }
+
+                ComUtilities.Release(ref candidate!);
+            }
+        }
+        finally
+        {
+            if (shapes != null)
+            {
+                ComUtilities.Release(ref shapes!);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Shape with id '{targetId}' not found on this slide. " +
+            $"Use shape(list) to see the current ShapeId values.");
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> and writes the parsed integer to
+    /// <paramref name="id"/> when <paramref name="value"/> matches the
+    /// <c>id:&lt;N&gt;</c> shape-reference syntax. Throws
+    /// <see cref="ArgumentException"/> when the prefix is present but the
+    /// suffix is not a valid integer.
+    /// </summary>
+    private static bool TryParseId(string value, out int id)
+    {
+        id = 0;
+        if (!value.StartsWith(IdPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string suffix = value[IdPrefix.Length..];
+        if (!int.TryParse(suffix, NumberStyles.Integer, CultureInfo.InvariantCulture, out id))
+        {
+            throw new ArgumentException(
+                $"Invalid shape reference '{value}'. The 'id:' prefix must be followed " +
+                $"by an integer ShapeId (e.g. 'id:42'). Use the literal shape name to " +
+                $"reference a shape whose name happens to start with 'id:'.",
+                nameof(value));
+        }
+
+        return true;
+    }
+}

--- a/tests/PptMcp.Core.Tests/Integration/Shape/ShapeResolverTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/Shape/ShapeResolverTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PptMcp.Core.Tests.Integration.Shape;
+
+/// <summary>
+/// Integration tests for stable shape identity via the 'id:N' prefix syntax on shapeName.
+/// Verifies that every shape-targeting ShapeCommands action resolves both:
+///   - by mutable Name (existing behavior, regression)
+///   - by stable Shape.Id via 'id:&lt;N&gt;' prefix (new)
+/// And that Id-based references survive a rename, while Name-based references break.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Shape")]
+[Trait("RequiresPowerPoint", "true")]
+[Collection("Sequential")]
+public class ShapeResolverTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly TempDirectoryFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private readonly ShapeCommands _shape = new();
+    private readonly SlideCommands _slide = new();
+
+    public ShapeResolverTests(TempDirectoryFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    private (int slideIndex, string name, int id) AddRectangle(IPptBatch batch, int slideIndex = 1)
+    {
+        // msoShapeRectangle = 1
+        var addResult = _shape.AddShape(batch, slideIndex, autoShapeType: 1, left: 100, top: 100, width: 200, height: 100);
+        Assert.True(addResult.Success, addResult.ErrorMessage);
+
+        var list = _shape.List(batch, slideIndex);
+        Assert.True(list.Success, list.ErrorMessage);
+        var added = list.Shapes[^1];
+        _output.WriteLine($"Added shape Id={added.ShapeId} Name='{added.Name}'");
+        return (slideIndex, added.Name, added.ShapeId);
+    }
+
+    [Fact]
+    public void Read_ByName_Succeeds_RegressionForExistingBehavior()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, name, _) = AddRectangle(batch);
+
+        var result = _shape.Read(batch, slideIndex, name);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(name, result.Shape.Name);
+    }
+
+    [Fact]
+    public void Read_ByIdPrefix_Succeeds()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, name, id) = AddRectangle(batch);
+
+        var result = _shape.Read(batch, slideIndex, $"id:{id}");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(id, result.Shape.ShapeId);
+        Assert.Equal(name, result.Shape.Name);
+    }
+
+    [Fact]
+    public void Read_ByIdPrefix_SurvivesRename()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, originalName, id) = AddRectangle(batch);
+
+        // Mutate the Name property out-of-band (simulates a user renaming in PowerPoint).
+        // We release the COM shape proxy explicitly so PowerPoint's Shapes lookup
+        // table picks up the new name on subsequent queries.
+        const string newName = "RenamedByUser";
+        batch.Execute((ctx, ct) =>
+        {
+            dynamic? slide = null;
+            dynamic? shape = null;
+            try
+            {
+                slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+                shape = slide.Shapes.Item(originalName);
+                shape.Name = newName;
+                return 0;
+            }
+            finally
+            {
+                if (shape != null) PptMcp.ComInterop.ComUtilities.Release(ref shape!);
+                if (slide != null) PptMcp.ComInterop.ComUtilities.Release(ref slide!);
+            }
+        });
+
+        // Confirm the rename actually took effect (sanity check).
+        var listAfter = _shape.List(batch, slideIndex);
+        Assert.True(listAfter.Success, listAfter.ErrorMessage);
+        Assert.Contains(listAfter.Shapes, s => s.ShapeId == id && s.Name == newName);
+
+        // The contract under test: Id-based lookup MUST resolve to the same shape
+        // after a rename, and report the new name.
+        var byId = _shape.Read(batch, slideIndex, $"id:{id}");
+        Assert.True(byId.Success, byId.ErrorMessage);
+        Assert.NotNull(byId.Shape);
+        Assert.Equal(newName, byId.Shape!.Name);
+        Assert.Equal(id, byId.Shape.ShapeId);
+    }
+
+    [Fact]
+    public void Read_InvalidIdPrefix_ThrowsDescriptiveError()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        AddRectangle(batch);
+
+        var ex = Record.Exception(() => _shape.Read(batch, slideIndex: 1, shapeName: "id:99999"));
+
+        Assert.NotNull(ex);
+        Assert.Contains("99999", ex.Message);
+    }
+
+    [Fact]
+    public void Read_MalformedIdPrefix_ThrowsDescriptiveError()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        AddRectangle(batch);
+
+        var ex = Record.Exception(() => _shape.Read(batch, slideIndex: 1, shapeName: "id:abc"));
+
+        Assert.NotNull(ex);
+        Assert.Contains("id:", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MoveResize_ByIdPrefix_AppliesToCorrectShape()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, _, id) = AddRectangle(batch);
+        var (_, _, otherId) = AddRectangle(batch, slideIndex);
+
+        Assert.NotEqual(id, otherId);
+
+        var result = _shape.MoveResize(batch, slideIndex, $"id:{id}", left: 50, top: 50, width: 300, height: 150);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var read = _shape.Read(batch, slideIndex, $"id:{id}");
+        Assert.Equal(50f, read.Shape.Left);
+        Assert.Equal(50f, read.Shape.Top);
+        Assert.Equal(300f, read.Shape.Width);
+        Assert.Equal(150f, read.Shape.Height);
+    }
+
+    [Fact]
+    public void Delete_ByIdPrefix_RemovesCorrectShape()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, _, idA) = AddRectangle(batch);
+        var (_, _, idB) = AddRectangle(batch, slideIndex);
+
+        var result = _shape.Delete(batch, slideIndex, $"id:{idA}");
+        Assert.True(result.Success, result.ErrorMessage);
+
+        var list = _shape.List(batch, slideIndex);
+        Assert.DoesNotContain(list.Shapes, s => s.ShapeId == idA);
+        Assert.Contains(list.Shapes, s => s.ShapeId == idB);
+    }
+
+    [Fact]
+    public void Group_AcceptsMixedNameAndIdPrefixReferences()
+    {
+        var file = _fixture.CreateTestFile();
+        using var batch = PptSession.BeginBatch(file);
+        _slide.Create(batch, position: 0, layoutName: "Blank");
+        var (slideIndex, nameA, _) = AddRectangle(batch);
+        var (_, _, idB) = AddRectangle(batch, slideIndex);
+
+        // Mix: one by name, one by id
+        var result = _shape.Group(batch, slideIndex, $"{nameA},id:{idB}");
+
+        Assert.True(result.Success, result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **stable shape identity** to every shape-targeting parameter on the `shape` tool. Each `shapeName` / `shapeNames` parameter now accepts either:

- A literal `Shape.Name` (existing behavior, fully backwards-compatible), or
- An `id:<N>` prefix that resolves by `Shape.Id` (e.g. `"id:42"`)

`Shape.Id` is assigned by PowerPoint at creation and is preserved across rename / copy-paste / reorder, so it's a safe handle for **multi-turn agent workflows** where `Name` may be edited between calls.

## Why

Currently every shape lookup goes through `Slide.Shapes.Item(shapeName)` — i.e. by mutable `Shape.Name`. This silently breaks agent workflows like:

1. Agent reads a shape and gets `"Rectangle 5"`.
2. A subsequent step renames it (placeholder formatting, user edit, …).
3. A later call passing `"Rectangle 5"` either fails or — worse — resolves to a *different* shape that happens to share the default name.

`Shape.Id` already exists in PowerPoint COM but PptMcp never surfaced or accepted it as a lookup key.

## Design — prefix-overload (not new parameters)

Introducing a parallel `shapeId` parameter would ripple through `IShapeCommands`, `ServiceRegistryGenerator`, `McpToolGenerator`, `CliSettingsGenerator`, every call site, and every test. Instead a single new `ShapeResolver` helper owns:

- Case-insensitive `id:` prefix detection
- `int.TryParse` with `InvariantCulture`
- `Shapes` enumeration by `Shape.Id` with COM proxies released in `finally`
- Descriptive errors (`InvalidOperationException` for unknown id, `ArgumentException` for malformed `id:` suffix)

→ Zero signature churn. MCP schema and CLI args are untouched.

## Changes

| File | Change |
|---|---|
| `src/PptMcp.Core/Commands/Shape/ShapeResolver.cs` | **New.** Single helper, ~120 lines, all COM cleanup in `finally`. |
| `src/PptMcp.Core/Commands/Shape/ShapeCommands.cs` | **32 call-site refactors** — single + multi-shape + connector + copy-formatting paths. The 2 integer-indexed `Shapes.Item(i)` enumerations are intentionally untouched. |
| `src/PptMcp.Core/Commands/Shape/IShapeCommands.cs` | Interface `<remarks>` + extended `[McpTool]` `Description` so the generated MCP tool schema documents `id:N` for LLMs. |
| `tests/PptMcp.Core.Tests/Integration/Shape/ShapeResolverTests.cs` | **New.** 8 integration tests under `[Collection("Sequential")]`. |
| `CHANGELOG.md` | New `### Added` entry under `[Unreleased]`. |

## Test coverage

| Test | Asserts |
|---|---|
| `Read_ByName_Succeeds_RegressionForExistingBehavior` | Existing name-based lookups still work |
| `Read_ByIdPrefix_Succeeds` | `"id:N"` resolves to the right shape |
| `Read_ByIdPrefix_SurvivesRename` | Id reference still works after the shape was renamed (the core feature, with a sanity check via `List`) |
| `Read_InvalidIdPrefix_ThrowsDescriptiveError` | Unknown id → descriptive error |
| `Read_MalformedIdPrefix_ThrowsDescriptiveError` | `"id:abc"` → descriptive error |
| `MoveResize_ByIdPrefix_AppliesToCorrectShape` | Id-based mutation works end-to-end |
| `Delete_ByIdPrefix_RemovesCorrectShape` | Id-based delete works end-to-end |
| `Group_AcceptsMixedNameAndIdPrefixReferences` | Multi-shape paths accept mixed name+id arrays |

## Verification

- ✅ **8 / 8** ShapeResolver integration tests pass deterministically (re-run after Scriban bump confirmed)
- ✅ `dotnet build PptMcp.sln`: **0 warnings, 0 errors**
- ✅ `scripts\check-com-leaks.ps1`: **0 leaks** (ShapeResolver.cs reported clean)
- ✅ `scripts\check-success-flag.ps1`: **0 violations**

## PowerPoint COM quirk (caught during TDD)

`Shapes.Item("OldName")` will *still resolve* a renamed shape if a COM proxy was held during the rename — exactly the silent-failure mode this PR fixes. The `SurvivesRename` test reflects that nuance: it asserts that the **id-based** lookup correctly finds the renamed shape (not that the old name fails — that behavior is unreliable).

## Stacked PR

This branch is stacked on `chore/bump-scriban` (#89) so the diff stays focused on the shape feature only. When #89 merges, this PR auto-retargets cleanly to `main`.

## Out of scope

- CLI flag changes — the prefix flows through the existing `--shape-name` argument unchanged
- Promotion to a typed `ShapeRef` parameter — would break the goal of zero signature churn
- Slide / Master / Layout id resolution — separate concern; shapes are the highest-churn surface

## Related

Closes #88

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
