### PR TITLE
fix(deps): bump Scriban 6.6.0 to 7.2.6 to unblock restore and CodeQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Scriban bumped 6.6.0 → 7.2.6**: resolves NU1904 (critical) and four NU1902 (moderate) NuGet audit advisories that broke `dotnet restore` and caused the scheduled CodeQL workflow to fail on `main` since July
+
 ### Added
 
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <!-- Template Engine for Skill Generation -->
-    <PackageVersion Include="Scriban" Version="6.6.0" />
+    <PackageVersion Include="Scriban" Version="7.2.6" />
     <!-- MSBuild Task Development -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />


### PR DESCRIPTION
## Problem

The scheduled `CodeQL Advanced Security` workflow has failed on `main` every week since mid-July. It is not a security finding — restore fails before CodeQL can build a database:

```
src\PptMcp.Build.Tasks\PptMcp.Build.Tasks.csproj : error NU1904: Warning As Error:
Package Scriban 6.6.0 has a known critical severity vulnerability
+ 4x error NU1902 (moderate)
  Failed to restore PptMcp.Build.Tasks.csproj
##[error]Process completed with exit code 1
CodeQL job status was configuration error
```

`TreatWarningsAsErrors` promotes the NuGet audit warnings to errors, so `dotnet restore` aborts.

## Fix

Bump `Scriban` 6.6.0 to 7.2.6 in `Directory.Packages.props`.

Bumped rather than suppressed via `NoWarn`, so the advisories are actually resolved. Scriban 7 is source compatible for our usage in `GenerateSkillFile.cs` — `Template.Parse`, `ScriptObject.Import(model, renamer)` and `TemplateContext.PushGlobal` are unchanged.

## Verification

- `dotnet restore PptMcp.sln --force` — clean, no NU190x
- `dotnet build PptMcp.sln -c Release` — 0 warnings, 0 errors

## Notes

`dotnet list package --vulnerable --include-transitive` still reports `MessagePack 2.5.198` and `Nerdbank.MessagePack 1.0.2`. Both are transitive only and no `AuditMode` is configured, so the default `direct` applies and they do not break the build. Out of scope here.
