### PR TITLE
fix: Advisories, zwei PowerPoint-COM-Bugs, Release-Versionsberechnung + Repository-Identität

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,25 @@
 
 > **🎯 Optimized for AI Coding Agents** - Modular, path-specific instructions
 
+## ⛔ Repository identity — read before any GitHub operation
+
+**This repository is `trsdn/mcp-server-ppt`. NEVER touch `sbroenne/mcp-server-excel`.**
+
+The project is registered as a fork of that upstream, but the histories have completely diverged (no shared root commit) and upstream belongs to someone else. Never open, close, or comment on upstream issues or PRs; never add an `upstream` remote; never merge or fetch from it.
+
+`gh` derives its target from the git remotes and silently prefers the **parent** repository when an `upstream` remote exists. Verify before acting:
+
+```powershell
+git remote -v              # exactly one remote pair, both trsdn/mcp-server-ppt
+gh repo set-default --view # trsdn/mcp-server-ppt
+```
+
+Full rationale and the incident that prompted this: [Rule 31](instructions/critical-rules.instructions.md) and [AGENTS.md](../AGENTS.md).
+
 ## 📋 Critical Files (Read These First)
 
 **ALWAYS read when working on code:**
-- [CRITICAL-RULES.md](instructions/critical-rules.instructions.md) - 27 mandatory rules (Success flag, COM cleanup, tests, etc.)
+- [CRITICAL-RULES.md](instructions/critical-rules.instructions.md) - 31 mandatory rules (repository identity, Success flag, COM cleanup, tests, etc.)
 - [Architecture Patterns](instructions/architecture-patterns.instructions.md) - Batch API, command pattern, resource management
 
 **Read based on task type:**

--- a/.github/instructions/critical-rules.instructions.md
+++ b/.github/instructions/critical-rules.instructions.md
@@ -72,7 +72,12 @@ Discovered while debugging a slide shape that referenced an embedded object
 
 ## Quick Reference (Grouped by Context)
 
-**Note:** Rules below are grouped by when you need them, not by number. Detailed rules follow in numeric order (1-21).
+**Note:** Rules below are grouped by when you need them, not by number. Detailed rules follow in numeric order (1-31).
+
+**Before ANY GitHub Operation:**
+| Rule | Action | Why Critical |
+|------|--------|--------------|
+| 31. Fork-only | This repo is `trsdn/mcp-server-ppt`. NEVER touch `sbroenne/mcp-server-excel` | Nearly closed issues in someone else's repository |
 
 **Every Edit:**
 | Rule | Action | Why Critical |
@@ -477,6 +482,7 @@ Delete commented-out code (use git history). Exception: Documentation files only
 | 28. COM API naming | Match COM param names when clear in flat schema | Always |
 | 29. TDD | Write test FIRST → RED → implement → GREEN | Always |
 | 30. Integration tests | NEVER write unit tests — integration tests only | Always |
+| 31. Fork-only | Repo is `trsdn/mcp-server-ppt`; never touch upstream | Before every `gh` command |
 
 
 
@@ -1126,4 +1132,62 @@ public void AddShape_ReportsProgress_DuringExecution()
 - The only acceptable non-integration tests are for pure algorithmic utilities with zero COM dependency (e.g., string parsing, enum mapping validation)
 
 **Historical Lesson:** 10 unit tests were written for the MCP progress feature (McpProgressAdapter mapping, ProgressContext AsyncLocal). All 10 passed. Zero of them would have caught the real bugs: STA thread affinity issues, COM callback re-entrancy during shape operations, or progress notifications not flowing through the generated code pipeline. The unit tests tested the unit tests.
+
+---
+
+## Rule 31: This Repository Is `trsdn/mcp-server-ppt` — Never Touch Upstream (CRITICAL)
+
+**Every repository operation targets `trsdn/mcp-server-ppt`. Never read from, write to, report on, or close anything in `sbroenne/mcp-server-excel`.**
+
+This project began as a port of a spreadsheet automation tool, but the histories have **completely diverged** — they do not even share a root commit. Upstream is unrelated code owned by someone else.
+
+### Never do this
+
+- ❌ Open, close, comment on, or modify **any** issue or PR in `sbroenne/mcp-server-excel`
+- ❌ Add an `upstream` remote, or any remote pointing at another owner's repository
+- ❌ Merge, rebase, or cherry-pick from upstream
+- ❌ Fetch upstream tags into this clone
+- ❌ Report upstream issues/PRs as if they belonged to this project
+
+### Always do this
+
+- ✅ Verify the target before **any** `gh` command that reads or writes repository state
+- ✅ Keep exactly one remote: `origin` → `https://github.com/trsdn/mcp-server-ppt.git`
+
+### Verification
+
+```powershell
+# Must print exactly one remote pair, both trsdn/mcp-server-ppt
+git remote -v
+
+# Must print trsdn/mcp-server-ppt
+gh repo set-default --view
+
+# Must list only this fork's tags (v1.0.0 - v1.0.3 as of this writing)
+git tag
+```
+
+If any check disagrees, repair it before continuing:
+
+```powershell
+git remote remove upstream
+gh repo set-default trsdn/mcp-server-ppt
+```
+
+### Why Critical
+
+`gh` resolves the target repository from git remotes. With an `upstream` remote present it silently prefers the **parent** repository, so `gh issue list` and `gh pr list` return upstream's data with no warning that you are looking at someone else's project.
+
+**This caused a real incident.** An agent reported upstream issues #777 and #750 and PR #751 as belonging to this project, and was moments away from closing issues in a repository it had no business touching. The correct answer was that this fork had zero open issues and zero open PRs.
+
+A stale `upstream` remote is also a live hazard: it carried a **push** URL, so a mistyped `git push upstream` would have written directly into another maintainer's repository.
+
+### Note on fork status
+
+`trsdn/mcp-server-ppt` is still a GitHub fork of `sbroenne/mcp-server-excel`, but this is metadata only. Detaching is **not** currently possible via self-service because the repository has child forks, and detaching would discard all stars, watchers, issues, PRs and child forks. The fork relationship is therefore expected to persist — which is exactly why the remote and `gh` default must stay pinned to this repository.
+
+### Note on release tags
+
+Only tags reachable on `origin` are meaningful here (`v1.0.0` - `v1.0.3`). No release tag is an ancestor of `main`, so `git describe --tags` **fails** in this repository. Any tooling that needs the latest version must sort semver tags directly rather than rely on ancestry. See `.github/workflows/release.yml`.
+
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,18 @@ jobs:
             VERSION="${{ inputs.custom_version }}"
             echo "Using custom version: ${VERSION}"
           else
-            # Get the latest tag
-            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            # Get the latest tag.
+            # Note: `git describe` only finds tags that are ancestors of HEAD.
+            # This repository has release tags that sit outside the current
+            # main history, so describe fails and would silently fall back to
+            # v0.0.0 - producing a version *below* what is already published.
+            # Sort all semver tags instead, which is independent of ancestry.
+            LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)
+
+            if [ -z "${LATEST_TAG}" ]; then
+              echo "No existing semver tag found, starting from v0.0.0"
+              LATEST_TAG="v0.0.0"
+            fi
             echo "Latest tag: ${LATEST_TAG}"
 
             # Remove 'v' prefix if present
@@ -73,6 +83,17 @@ jobs:
 
             # Parse version components
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+            # Fail loudly rather than emit a bogus version from arithmetic on
+            # non-numeric input.
+            for component in "${MAJOR}" "${MINOR}" "${PATCH}"; do
+              case "${component}" in
+                ''|*[!0-9]*)
+                  echo "::error::Could not parse '${LATEST_TAG}' as a semver tag"
+                  exit 1
+                  ;;
+              esac
+            done
 
             # Increment based on bump type
             case "${{ inputs.version_bump }}" in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+---
+
+## 0. Repository identity — read this before anything else
+
+**This repository is `trsdn/mcp-server-ppt`. Every operation targets it and only it.**
+
+`trsdn/mcp-server-ppt` is registered on GitHub as a fork of `sbroenne/mcp-server-excel`, but that is metadata only. The two projects have **completely diverged** — they do not share a root commit, and upstream is unrelated spreadsheet automation code owned by someone else.
+
+### Never
+
+- ❌ Open, close, comment on, or modify **any** issue or pull request in `sbroenne/mcp-server-excel`
+- ❌ Add an `upstream` remote, or any remote pointing at a repository you do not own
+- ❌ Merge, rebase, or cherry-pick from upstream
+- ❌ Fetch upstream tags into this clone
+- ❌ Report upstream issues or PRs as if they belonged to this project
+
+### Always
+
+- ✅ Confirm the target repository before **any** `gh` command that reads or writes state
+- ✅ Keep exactly one remote: `origin` → `https://github.com/trsdn/mcp-server-ppt.git`
+
+### Verify
+
+```powershell
+git remote -v              # exactly one remote pair, both trsdn/mcp-server-ppt
+gh repo set-default --view # trsdn/mcp-server-ppt
+git tag                    # only this fork's tags (v1.0.0 - v1.0.3)
+```
+
+Repair if any check disagrees:
+
+```powershell
+git remote remove upstream
+gh repo set-default trsdn/mcp-server-ppt
+```
+
+### Why this warning exists
+
+`gh` derives its target from the git remotes. When an `upstream` remote is present it silently prefers the **parent** repository — so `gh issue list` and `gh pr list` return upstream's data with no indication that you are reading someone else's project.
+
+This caused a real incident: an agent reported upstream issues #777 and #750 and PR #751 as belonging to this project, and was about to close issues in a repository it had no business touching. The correct answer was that this fork had zero open issues and zero open PRs.
+
+The stale remote was also a live hazard — it carried a **push** URL, so a mistyped `git push upstream` would have written straight into another maintainer's repository.
+
+**The fork relationship cannot currently be dissolved.** GitHub's "Leave fork network" requires the repository to have no child forks; this one has several. Detaching would also discard all stars, watchers, issues, PRs and child forks. So the fork status will persist — which is precisely why the remote and the `gh` default must stay pinned.
+
+---
+
+## 1. What this project is
+
+**PptMcp** is a Windows-only toolset for programmatic PowerPoint automation via COM interop, aimed at coding agents and automation scripts.
+
+There are **two equal entry points**, and every feature must work identically through both:
+
+| Entry point | Path | Transport |
+|---|---|---|
+| MCP Server | `src/PptMcp.McpServer` | in-process |
+| CLI | `src/PptMcp.CLI` | daemon over named pipe |
+
+Supporting layers: `PptMcp.ComInterop` (COM patterns, STA threading, sessions), `PptMcp.Core` (PowerPoint business logic), `PptMcp.Service` (session management and routing), `PptMcp.Generators*` (source generators for CLI commands and MCP tools).
+
+---
+
+## 2. Non-negotiable rules
+
+The authoritative list lives in [`.github/instructions/critical-rules.instructions.md`](.github/instructions/critical-rules.instructions.md). The ones that bite most often:
+
+| Rule | Summary |
+|---|---|
+| 0 | Never commit without running the tests for what you changed |
+| 1 | Never set `Success = true` alongside an `ErrorMessage` |
+| 1b | Never wrap `batch.Execute()` in a catch that returns an error result — let exceptions propagate |
+| 16 | Test **only** the feature you touched; the full suite takes 45+ minutes |
+| 21 | **Never commit, push, or merge without explicit user approval** |
+| 22 | COM cleanup belongs in `finally`, never in a swallowing `catch` |
+| 24 | After changing a tool or action, sync **all** touchpoints (CLI, MCP, skills, READMEs, counts) |
+| 26 | No confidential customer or project names in commits, PRs, or issues |
+| 27 | Update `CHANGELOG.md` before merging |
+| 29 | TDD: write the test first, watch it fail, then implement |
+| 30 | Integration tests only — mocked COM tests prove nothing |
+| 31 | Fork-only; see section 0 above |
+
+---
+
+## 3. Building and testing
+
+```powershell
+dotnet build PptMcp.sln -c Release      # must finish 0 warnings / 0 errors
+
+# Surgical testing — pick the feature you changed
+dotnet test tests\PptMcp.Core.Tests -c Release --no-build --filter "Feature=Slide&RunType!=OnDemand"
+
+# End-to-end smoke test against real PowerPoint
+.\scripts\Test-CliWorkflow.ps1
+
+# Pre-commit gates
+.\scripts\check-com-leaks.ps1
+.\scripts\pre-commit.ps1
+```
+
+**If the build fails with `MSB3027` (file locked):** a `pptcli` daemon or MSBuild node still holds the output.
+
+```powershell
+Get-Process pptcli -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.Id -Force }
+dotnet build-server shutdown
+Start-Sleep 4
+```
+
+Integration tests need PowerPoint installed and are slow (roughly 20-30 s per test). The first run after a rebuild is occasionally flaky from leftover daemon state — re-run once before believing a failure.
+
+---
+
+## 4. PowerPoint COM pitfalls
+
+Hard-won specifics that are easy to get wrong:
+
+- **`Presentation.SlideMasters` does not exist.** Masters are reached through `Presentation.Designs.Item(i).SlideMaster`, one master per design.
+- **Layout names are localized**, and so is `CustomLayout.MatchingName`. There is no locale-independent layout identifier in the COM API. Resolve in stages: exact `Name`, then `MatchingName`, then position within the first design using the canonical Office layout order, which is identical across locales.
+- **Indices are 1-based.** Use `Slides.Item(index)`.
+- **Z-order changes require explicit reordering.**
+- Before writing new COM code, look for a working example in another open-source project. [NetOffice](https://github.com/NetOfficeFw/NetOffice) is the best reference for essentially any PowerPoint COM API.
+
+---
+
+## 5. Release notes
+
+Release tags on `origin` are `v1.0.0` through `v1.0.3`. **No release tag is an ancestor of `main`**, so `git describe --tags` fails in this repository.
+
+Any tooling that derives the current version must sort semver tags directly rather than rely on ancestry — `git describe` silently falling back to `v0.0.0` would produce a version *below* what is already published. See `.github/workflows/release.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Scriban bumped 6.6.0 → 7.2.6**: resolves NU1904 (critical) and four NU1902 (moderate) NuGet audit advisories that broke `dotnet restore` and caused the scheduled CodeQL workflow to fail on `main` since July
 - **StreamJsonRpc bumped 2.24.84 → 2.25.29**: clears the transitive `MessagePack` 2.5.198 (2 high, 9 moderate) and `Nerdbank.MessagePack` 1.0.2 (1 high, 2 moderate) advisories. `dotnet list package --vulnerable --include-transitive` is now empty
 
+### Fixed
+
+- **`master` tool threw `RuntimeBinderException` on every action**: `list`, `list-shapes`, `edit-shape-text` and `list-layouts` all read `Presentation.SlideMasters`, which does not exist in the PowerPoint COM API.
+  - ROOT CAUSE: property carried over from a spreadsheet-oriented code base; PowerPoint exposes masters through `Presentation.Designs.Item(i).SlideMaster` (one master per design)
+  - FIX: added a shared `GetMaster(presentation, masterIndex)` helper that resolves masters through `Designs`, and routed all four actions through it
+- **Layout lookup failed on non-English Office installations**: `slide create --layout Blank` and `slide apply-layout` raised "layout not found" because `CustomLayout.Name` and `CustomLayout.MatchingName` are both localized (for example `Leer`, `Titelfolie`, `Zwei Inhalte` on a German install).
+  - ROOT CAUSE: lookup compared only against the localized `Name`, and the COM API exposes no locale-independent layout identifier
+  - FIX: `FindLayout` now resolves in stages — exact `Name`, then `MatchingName`, then position within the first design using the canonical Office layout order (which is identical across locales). Canonical English names and numeric indices both work; the not-found message now lists the layouts that are actually available
+
 ### Added
 
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Layout lookup failed on non-English Office installations**: `slide create --layout Blank` and `slide apply-layout` raised "layout not found" because `CustomLayout.Name` and `CustomLayout.MatchingName` are both localized (for example `Leer`, `Titelfolie`, `Zwei Inhalte` on a German install).
   - ROOT CAUSE: lookup compared only against the localized `Name`, and the COM API exposes no locale-independent layout identifier
   - FIX: `FindLayout` now resolves in stages — exact `Name`, then `MatchingName`, then position within the first design using the canonical Office layout order (which is identical across locales). Canonical English names and numeric indices both work; the not-found message now lists the layouts that are actually available
+- **Release workflow would have published a version below the current release**: the next release was calculated as `v0.1.0` even though `v1.0.3` is already published.
+  - ROOT CAUSE: `git describe --tags` only finds tags that are ancestors of `HEAD`. No release tag is an ancestor of `main` in this repository, so the command failed and the `|| echo "v0.0.0"` fallback silently swallowed the error
+  - FIX: the workflow now selects the highest semver tag with `git tag -l --sort=-v:refname`, which is independent of ancestry, and fails loudly if the tag cannot be parsed instead of emitting a bogus version
 
 ### Added
+
+- **`AGENTS.md`** at the repository root, documenting repository identity, the two equal entry points, build and test commands, and the PowerPoint COM pitfalls that are easy to get wrong
+- **Rule 31 (repository identity)** in the critical rules: this project is `trsdn/mcp-server-ppt` and must never read from or write to its upstream. `gh` silently resolves to the parent repository when an `upstream` remote is present, which previously caused upstream issues to be misreported as belonging to this project
 
 - Official source-side Copilot SDK agent client under `src\PptMcp.Agent`, including local planner tests and documentation for the agent architecture
 - Dedicated documentation for the evaluation framework and the archetype/reference pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 
 - **Scriban bumped 6.6.0 → 7.2.6**: resolves NU1904 (critical) and four NU1902 (moderate) NuGet audit advisories that broke `dotnet restore` and caused the scheduled CodeQL workflow to fail on `main` since July
+- **StreamJsonRpc bumped 2.24.84 → 2.25.29**: clears the transitive `MessagePack` 2.5.198 (2 high, 9 moderate) and `Nerdbank.MessagePack` 1.0.2 (1 high, 2 moderate) advisories. `dotnet list package --vulnerable --include-transitive` is now empty
 
 ### Added
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.4" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
     <PackageVersion Include="System.Text.Json" Version="10.0.3" />
     <!-- MCP SDK - Latest stable preview -->
     <PackageVersion Include="ModelContextProtocol" Version="0.9.0-preview.2" />

--- a/src/PptMcp.Core/Commands/Master/MasterCommands.cs
+++ b/src/PptMcp.Core/Commands/Master/MasterCommands.cs
@@ -7,20 +7,54 @@ namespace PptMcp.Core.Commands.Master;
 
 public class MasterCommands : IMasterCommands
 {
+    /// <summary>
+    /// PowerPoint COM has no Presentation.SlideMasters collection. Masters are reached
+    /// through Presentation.Designs, where each Design exposes exactly one SlideMaster.
+    /// </summary>
+    private static dynamic GetMaster(dynamic pres, int masterIndex)
+    {
+        dynamic designs = pres.Designs;
+        try
+        {
+            int designCount = (int)designs.Count;
+            if (masterIndex < 1 || masterIndex > designCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(masterIndex),
+                    $"Master index {masterIndex} is out of range. Presentation has {designCount} master(s).");
+            }
+
+            dynamic design = designs.Item(masterIndex);
+            try
+            {
+                return design.SlideMaster;
+            }
+            finally
+            {
+                ComUtilities.Release(ref design!);
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref designs!);
+        }
+    }
+
     public MasterListResult List(IPptBatch batch)
     {
         return batch.Execute((ctx, ct) =>
         {
             var result = new MasterListResult { Success = true, FilePath = ctx.PresentationPath };
             dynamic pres = ctx.Presentation;
-            dynamic masters = pres.SlideMasters;
+            dynamic designs = pres.Designs;
             try
             {
-                int masterCount = (int)masters.Count;
+                int masterCount = (int)designs.Count;
 
                 for (int m = 1; m <= masterCount; m++)
                 {
-                    dynamic master = masters.Item(m);
+                    dynamic design = designs.Item(m);
+                    dynamic master = design.SlideMaster;
                     try
                     {
                         var masterInfo = new MasterInfo
@@ -59,6 +93,7 @@ public class MasterCommands : IMasterCommands
                     finally
                     {
                         ComUtilities.Release(ref master!);
+                        ComUtilities.Release(ref design!);
                     }
                 }
 
@@ -66,7 +101,7 @@ public class MasterCommands : IMasterCommands
             }
             finally
             {
-                ComUtilities.Release(ref masters!);
+                ComUtilities.Release(ref designs!);
             }
         });
     }
@@ -75,8 +110,7 @@ public class MasterCommands : IMasterCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic masters = ((dynamic)ctx.Presentation).SlideMasters;
-            dynamic master = masters.Item(masterIndex);
+            dynamic master = GetMaster(ctx.Presentation, masterIndex);
             dynamic shapes = master.Shapes;
             try
             {
@@ -113,7 +147,6 @@ public class MasterCommands : IMasterCommands
             {
                 ComUtilities.Release(ref shapes!);
                 ComUtilities.Release(ref master!);
-                ComUtilities.Release(ref masters!);
             }
         });
     }
@@ -124,8 +157,7 @@ public class MasterCommands : IMasterCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic masters = ((dynamic)ctx.Presentation).SlideMasters;
-            dynamic master = masters.Item(masterIndex);
+            dynamic master = GetMaster(ctx.Presentation, masterIndex);
             dynamic shape = master.Shapes.Item(shapeName);
             try
             {
@@ -146,7 +178,6 @@ public class MasterCommands : IMasterCommands
             {
                 ComUtilities.Release(ref shape!);
                 ComUtilities.Release(ref master!);
-                ComUtilities.Release(ref masters!);
             }
         });
     }
@@ -155,8 +186,7 @@ public class MasterCommands : IMasterCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic masters = ((dynamic)ctx.Presentation).SlideMasters;
-            dynamic master = masters.Item(masterIndex);
+            dynamic master = GetMaster(ctx.Presentation, masterIndex);
             dynamic layouts = master.CustomLayouts;
             try
             {
@@ -200,7 +230,6 @@ public class MasterCommands : IMasterCommands
             {
                 ComUtilities.Release(ref layouts!);
                 ComUtilities.Release(ref master!);
-                ComUtilities.Release(ref masters!);
             }
         });
     }

--- a/src/PptMcp.Core/Commands/Slide/SlideCommands.cs
+++ b/src/PptMcp.Core/Commands/Slide/SlideCommands.cs
@@ -116,7 +116,7 @@ public class SlideCommands : ISlideCommands
             // Find the layout by name
             dynamic? layout = FindLayout(pres, layoutName);
             if (layout == null)
-                throw new ArgumentException($"Layout '{layoutName}' not found in this presentation.");
+                throw new ArgumentException(BuildLayoutNotFoundMessage(pres, layoutName));
 
             try
             {
@@ -235,7 +235,7 @@ public class SlideCommands : ISlideCommands
             dynamic? layout = FindLayout(pres, layoutName);
 
             if (layout == null)
-                throw new ArgumentException($"Layout '{layoutName}' not found in this presentation.");
+                throw new ArgumentException(BuildLayoutNotFoundMessage(pres, layoutName));
 
             try
             {
@@ -557,6 +557,29 @@ public class SlideCommands : ISlideCommands
         }
     }
 
+    /// <summary>
+    /// Canonical English names of the 11 layouts every Office theme ships, mapped to their
+    /// fixed 1-based position in the master. PowerPoint localizes CustomLayout.Name and
+    /// CustomLayout.MatchingName (on a German install "Blank" is reported as "Leer") and the
+    /// COM API exposes no locale-independent identifier, so position is the only stable
+    /// bridge from an English name to a localized layout.
+    /// </summary>
+    private static readonly Dictionary<string, int> CanonicalLayoutPositions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Title Slide"] = 1,
+            ["Title and Content"] = 2,
+            ["Section Header"] = 3,
+            ["Two Content"] = 4,
+            ["Comparison"] = 5,
+            ["Title Only"] = 6,
+            ["Blank"] = 7,
+            ["Content with Caption"] = 8,
+            ["Picture with Caption"] = 9,
+            ["Title and Vertical Text"] = 10,
+            ["Vertical Title and Text"] = 11,
+        };
+
     private static dynamic? FindLayout(dynamic pres, string layoutName)
     {
         // PowerPoint COM: Presentation.Designs → Design.SlideMaster.CustomLayouts
@@ -564,6 +587,13 @@ public class SlideCommands : ISlideCommands
         try
         {
             int designCount = (int)designs.Count;
+
+            bool wantsPosition = CanonicalLayoutPositions.TryGetValue(layoutName, out int canonicalPosition);
+            bool wantsIndex = int.TryParse(layoutName, out int requestedIndex) && requestedIndex >= 1;
+
+            dynamic? nameMatch = null;
+            dynamic? matchingNameMatch = null;
+            dynamic? positionMatch = null;
 
             for (int d = 1; d <= designCount; d++)
             {
@@ -577,11 +607,34 @@ public class SlideCommands : ISlideCommands
                     for (int l = 1; l <= layoutCount; l++)
                     {
                         dynamic layout = layouts.Item(l);
+
                         string name = layout.Name?.ToString() ?? "";
-                        if (string.Equals(name, layoutName, StringComparison.OrdinalIgnoreCase))
+                        if (nameMatch == null && string.Equals(name, layoutName, StringComparison.OrdinalIgnoreCase))
                         {
-                            return layout;
+                            nameMatch = layout;
+                            continue;
                         }
+
+                        string matchingName = TryGetMatchingName(layout);
+                        if (matchingNameMatch == null && matchingName.Length > 0
+                            && string.Equals(matchingName, layoutName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            matchingNameMatch = layout;
+                            continue;
+                        }
+
+                        // Positional fallbacks only apply to the first design, where the
+                        // standard Office layout order is meaningful.
+                        bool positionalHit = d == 1
+                            && positionMatch == null
+                            && ((wantsPosition && l == canonicalPosition) || (wantsIndex && l == requestedIndex));
+
+                        if (positionalHit)
+                        {
+                            positionMatch = layout;
+                            continue;
+                        }
+
                         ComUtilities.Release(ref layout!);
                     }
                 }
@@ -593,12 +646,110 @@ public class SlideCommands : ISlideCommands
                 }
             }
 
-            return null;
+            // An exact name always wins over a localized positional guess.
+            if (nameMatch != null)
+            {
+                ReleaseIfNotNull(ref matchingNameMatch);
+                ReleaseIfNotNull(ref positionMatch);
+                return nameMatch;
+            }
+
+            if (matchingNameMatch != null)
+            {
+                ReleaseIfNotNull(ref positionMatch);
+                return matchingNameMatch;
+            }
+
+            return positionMatch;
         }
         finally
         {
             ComUtilities.Release(ref designs!);
         }
+    }
+
+    /// <summary>
+    /// CustomLayout.MatchingName is not present on every layout object PowerPoint hands back,
+    /// so probe it defensively. Only late-binding and COM failures are tolerated here.
+    /// </summary>
+    private static string TryGetMatchingName(dynamic layout)
+    {
+        try
+        {
+            return layout.MatchingName?.ToString() ?? "";
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
+        {
+            return "";
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return "";
+        }
+    }
+
+    private static void ReleaseIfNotNull(ref dynamic? comObject)
+    {
+        if (comObject != null)
+        {
+            ComUtilities.Release(ref comObject!);
+            comObject = null;
+        }
+    }
+
+    /// <summary>
+    /// Builds an error message that lists the layouts PowerPoint actually reports, so a
+    /// caller on a localized install can see the real names instead of guessing.
+    /// </summary>
+    private static string BuildLayoutNotFoundMessage(dynamic pres, string layoutName)
+    {
+        var available = new List<string>();
+
+        dynamic designs = pres.Designs;
+        try
+        {
+            int designCount = (int)designs.Count;
+            for (int d = 1; d <= designCount; d++)
+            {
+                dynamic design = designs.Item(d);
+                dynamic master = design.SlideMaster;
+                dynamic layouts = master.CustomLayouts;
+                try
+                {
+                    int layoutCount = (int)layouts.Count;
+                    for (int l = 1; l <= layoutCount; l++)
+                    {
+                        dynamic layout = layouts.Item(l);
+                        try
+                        {
+                            string name = ComUtilities.SafeGetString(layout, "Name");
+                            if (name.Length == 0)
+                                name = $"Layout {l}";
+                            available.Add($"{l}. {name.Replace("\r", "").Replace("\n", " ")}");
+                        }
+                        finally
+                        {
+                            ComUtilities.Release(ref layout!);
+                        }
+                    }
+                }
+                finally
+                {
+                    ComUtilities.Release(ref layouts!);
+                    ComUtilities.Release(ref master!);
+                    ComUtilities.Release(ref design!);
+                }
+            }
+        }
+        finally
+        {
+            ComUtilities.Release(ref designs!);
+        }
+
+        return $"Layout '{layoutName}' not found in this presentation. " +
+            $"Available layouts: {string.Join(", ", available)}. " +
+            "Layout names are localized by PowerPoint; canonical English names " +
+            "(for example 'Blank' or 'Title Slide') and 1-based indexes are also accepted.";
     }
 
     public OperationResult CopyToClipboard(IPptBatch batch, int slideIndex)

--- a/tests/PptMcp.CLI.Tests/Integration/MasterCommandTests.cs
+++ b/tests/PptMcp.CLI.Tests/Integration/MasterCommandTests.cs
@@ -1,0 +1,106 @@
+using PptMcp.CLI.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PptMcp.CLI.Tests.Integration;
+
+[Collection("Service")]
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "Master")]
+[Trait("RequiresPowerPoint", "true")]
+[Trait("Speed", "Fast")]
+public sealed class MasterCommandTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MasterCommandTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task List_ReturnsMastersWithLayouts()
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync($"master list --session {sessionId}");
+            _output.WriteLine(result.Stdout);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+            var masters = json.RootElement.GetProperty("masters");
+            Assert.NotEmpty(masters.EnumerateArray());
+
+            var first = masters.EnumerateArray().First();
+            Assert.False(string.IsNullOrWhiteSpace(first.GetProperty("name").GetString()));
+            Assert.NotEmpty(first.GetProperty("layouts").EnumerateArray());
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ListLayouts_ForFirstMaster_ReturnsLayouts()
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                $"master list-layouts --session {sessionId} --master-index 1");
+            _output.WriteLine(result.Stdout);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+            Assert.Contains("layout", json.RootElement.GetProperty("message").GetString()!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ListShapes_ForFirstMaster_Succeeds()
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                $"master list-shapes --session {sessionId} --master-index 1");
+            _output.WriteLine(result.Stdout);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    private static async Task<(string SessionId, string FilePath)> CreateSessionAsync()
+    {
+        var filePath = Path.Join(Path.GetTempPath(), $"CliMasterCommandTests_{Guid.NewGuid():N}.pptx");
+        var (result, json) = await CliProcessHelper.RunJsonAsync($"session create \"{filePath}\"");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+        return (json.RootElement.GetProperty("sessionId").GetString()!, filePath);
+    }
+
+    private static async Task CloseSessionAsync(string? sessionId, string filePath)
+    {
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            await CliProcessHelper.RunAsync($"session close --session {sessionId} --save false");
+        }
+
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/tests/PptMcp.CLI.Tests/Integration/SlideLayoutLookupTests.cs
+++ b/tests/PptMcp.CLI.Tests/Integration/SlideLayoutLookupTests.cs
@@ -1,0 +1,127 @@
+using PptMcp.CLI.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PptMcp.CLI.Tests.Integration;
+
+/// <summary>
+/// Layout names reported by PowerPoint are localized ("Blank" is "Leer" on a German
+/// install), so looking a layout up by its English name has to work regardless of the
+/// UI language of the machine running the tests.
+/// </summary>
+[Collection("Service")]
+[Trait("Layer", "CLI")]
+[Trait("Category", "Integration")]
+[Trait("Feature", "Slide")]
+[Trait("RequiresPowerPoint", "true")]
+[Trait("Speed", "Fast")]
+public sealed class SlideLayoutLookupTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SlideLayoutLookupTests(ITestOutputHelper output) => _output = output;
+
+    [Theory]
+    [InlineData("Blank")]
+    [InlineData("Title Slide")]
+    [InlineData("Title and Content")]
+    [InlineData("Two Content")]
+    public async Task Create_WithCanonicalEnglishLayoutName_Succeeds(string layoutName)
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                $"slide create --session {sessionId} --position 0 --layout-name \"{layoutName}\"");
+            _output.WriteLine(result.Stdout);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+            var (listResult, listJson) = await CliProcessHelper.RunJsonAsync($"slide list --session {sessionId}");
+            _output.WriteLine(listResult.Stdout);
+
+            Assert.True(listJson.RootElement.GetProperty("success").GetBoolean());
+            Assert.NotEmpty(listJson.RootElement.GetProperty("slides").EnumerateArray());
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    [Fact]
+    public async Task Create_WithLocalizedLayoutName_StillSucceeds()
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (_, layoutsJson) = await CliProcessHelper.RunJsonAsync(
+                $"master list --session {sessionId}");
+
+            var firstLayoutName = layoutsJson.RootElement
+                .GetProperty("masters").EnumerateArray().First()
+                .GetProperty("layouts").EnumerateArray().First()
+                .GetProperty("name").GetString()!;
+
+            _output.WriteLine($"Using layout reported by PowerPoint: {firstLayoutName}");
+
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                $"slide create --session {sessionId} --position 0 --layout-name \"{firstLayoutName}\"");
+            _output.WriteLine(result.Stdout);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    [Fact]
+    public async Task Create_WithUnknownLayoutName_ListsAvailableLayouts()
+    {
+        var (sessionId, filePath) = await CreateSessionAsync();
+        try
+        {
+            var (result, json) = await CliProcessHelper.RunJsonAsync(
+                $"slide create --session {sessionId} --position 0 --layout-name \"DefinitelyNotALayout\"");
+            _output.WriteLine(result.Stdout);
+
+            Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+            var error = json.RootElement.GetProperty("error").GetString()!;
+            Assert.Contains("DefinitelyNotALayout", error, StringComparison.Ordinal);
+            Assert.Contains("Available", error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await CloseSessionAsync(sessionId, filePath);
+        }
+    }
+
+    private static async Task<(string SessionId, string FilePath)> CreateSessionAsync()
+    {
+        var filePath = Path.Join(Path.GetTempPath(), $"CliSlideLayoutTests_{Guid.NewGuid():N}.pptx");
+        var (result, json) = await CliProcessHelper.RunJsonAsync($"session create \"{filePath}\"");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+        return (json.RootElement.GetProperty("sessionId").GetString()!, filePath);
+    }
+
+    private static async Task CloseSessionAsync(string? sessionId, string filePath)
+    {
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            await CliProcessHelper.RunAsync($"session close --session {sessionId} --save false");
+        }
+
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Was hier drin ist

Ursprünglich als reines Dependency-Update gestartet. Die Verifikation deckte nacheinander drei weitere, **vorbestehende** Defekte auf — zwei im Produktcode, einer im Release-Workflow. Alle blockierten das Release, deshalb sind sie hier mitbehoben.

---

### 1. Dependency: StreamJsonRpc 2.24.84 → 2.25.29

`dotnet nuget why` zeigte, dass beide transitiven Advisory-Ketten aus StreamJsonRpc stammen:

- `MessagePack` 2.5.198 — 2 high, 9 moderate
- `Nerdbank.MessagePack` 1.0.2 — 1 high, 2 moderate

Nach dem Bump ist `dotnet list package --vulnerable --include-transitive` leer.

> StreamJsonRpc trägt die Named-Pipe des CLI-Daemons — ein Compile-Check genügt hier nicht. Der E2E-Smoke-Test war rot. Gegenprobe mit gestashter Änderung ergab **identisch 7 pass / 4 fail**, womit bewiesen war: keine Regression, sondern zwei echte Bugs.

---

### 2. `master`-Tool warf `RuntimeBinderException` bei jeder Aktion

```
'__ComObject' does not contain a definition for 'SlideMasters'
```

**Ursache:** `Presentation.SlideMasters` existiert in der PowerPoint-COM-API nicht. Master sind über `Presentation.Designs.Item(i).SlideMaster` erreichbar — ein Master je Design. `DeleteUnused` in derselben Datei nutzte bereits diesen Weg und bestätigte die korrekte API.

**Fix:** Gemeinsamer Helper `GetMaster(presentation, masterIndex)`; `list`, `list-shapes`, `edit-shape-text` und `list-layouts` laufen jetzt darüber.

---

### 3. Layout-Suche scheiterte auf nicht-englischen Office-Installationen

`slide create --layout Blank` meldete „layout not found", weil sowohl `CustomLayout.Name` als auch `CustomLayout.MatchingName` lokalisiert sind (deutsch z. B. `Leer`, `Titelfolie`, `Zwei Inhalte`). Die COM-API bietet keinen locale-unabhängigen Layout-Identifier.

**Fix:** `FindLayout` löst mehrstufig auf — exakter `Name`, dann `MatchingName`, dann Position im ersten Design anhand der kanonischen Office-Layoutreihenfolge, die über alle Sprachen identisch ist. Kanonische englische Namen *und* numerische Indizes funktionieren. Die Not-found-Meldung listet jetzt die tatsächlich vorhandenen Layouts.

---

### 4. Release-Workflow hätte eine Version *unterhalb* des aktuellen Releases publiziert

```bash
LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
```

`git describe` findet nur Tags, die **Vorfahren von HEAD** sind. In diesem Repository ist **kein einziger** Release-Tag Vorfahre von `main` — die Historien sind vollständig getrennt. Der Befehl scheiterte also immer, und `|| echo "v0.0.0"` schluckte den Fehler still. Der nächste Release wäre **`v0.1.0`** geworden, obwohl `v1.0.3` bereits veröffentlicht ist. Das erklärt auch den Wert `0.1.0` in `Directory.Build.props`.

**Fix:** Auswahl des höchsten Semver-Tags per `git tag -l --sort=-v:refname` (ancestry-unabhängig), plus lautes Scheitern bei nicht parsebaren Tags statt stiller Falschberechnung.

Gegen die echten Tag-Listen verifiziert:

| Fall | Erwartet | Ergebnis |
|---|---|---|
| minor bump | `1.1.0` | ✅ |
| patch bump | `1.0.4` | ✅ |
| major bump | `2.0.0` | ✅ |
| leeres Tag-Set | `0.1.0` | ✅ |
| `v1.10.0` schlägt `v1.9.0` (numerisch, nicht lexikografisch) | `1.10.1` | ✅ |
| ignoriert `latest` und `v1.0` | `1.1.0` | ✅ |

---

### 5. Repository-Identität festgeschrieben

`gh` leitet das Zielrepository aus den Git-Remotes ab und bevorzugt bei vorhandenem `upstream`-Remote **stillschweigend das Elternrepository**. Dadurch wurden fremde Issues und PRs als zu diesem Projekt gehörig gemeldet — beinahe wären Issues in einem fremden Repository geschlossen worden. Der veraltete Remote trug zudem eine **Push**-URL.

Neu: `AGENTS.md` im Root und **Rule 31** in den kritischen Regeln. Beide halten fest, dass dieses Repository `trsdn/mcp-server-ppt` ist, dass Upstream weder gelesen noch beschrieben wird, und wie die Remote-Konfiguration geprüft und repariert wird.

Ebenfalls dokumentiert: Die Fork-Beziehung lässt sich derzeit **nicht** auflösen — GitHubs „Leave fork network" setzt voraus, dass keine Child-Forks existieren (hier gibt es mehrere), und ein Detach würde Stars, Watcher, Issues und PRs verwerfen.

`AGENTS.md` hält außerdem Build- und Testkommandos, die Dateisperren-Recovery und die oben behobenen COM-Fallstricke fest, damit sie nicht erneut mühsam entdeckt werden.

---

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `Test-CliWorkflow.ps1` (E2E, echtes PowerPoint) | **11 pass / 0 fail** (vorher 7/4) |
| `PptMcp.CLI.Tests` | 58/58 (9 neue) |
| `PptMcp.Core.Tests` | 481/481 |
| `PptMcp.McpServer.Tests` | 94/94 |
| `check-com-leaks.ps1` | 33 Dateien sauber, 0 Leaks |
| Release-Build | 0 Warnungen / 0 Fehler |
| `dotnet list package --vulnerable --include-transitive` | leer |
| Versionsberechnung | 6/6 Fälle |
| `release.yml` | YAML valide, 10 Jobs, `fetch-depth: 0` vorhanden |

Beide Produktbugfixes wurden TDD-konform entwickelt: Tests zuerst, RED verifiziert, dann implementiert, dann GREEN.

## Tests

- `tests/PptMcp.CLI.Tests/Integration/MasterCommandTests.cs` — 3 Tests, deckten Bug 2 auf
- `tests/PptMcp.CLI.Tests/Integration/SlideLayoutLookupTests.cs` — 6 Tests: kanonische englische Namen, lokalisierter Name, Fehlermeldung

CHANGELOG unter `[Unreleased]` in `### Security`, `### Fixed` und `### Added` gepflegt.