### PR TITLE
fix(release): fail when a skill package would ship without its references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -493,17 +493,45 @@ jobs:
       run: |
         $version = $env:VERSION
 
-        # Populate ppt-mcp-skill
-        $mcpTarget = "packages/ppt-mcp-skill/skills/ppt-mcp"
-        Get-ChildItem $mcpTarget -Exclude ".gitkeep" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
-        Copy-Item "skills/ppt-mcp/SKILL.md" $mcpTarget
-        Copy-Item "skills/ppt-mcp/references" "$mcpTarget/references" -Recurse -ErrorAction SilentlyContinue
+        # These packages are what npm publishes. A skill shipped without its
+        # references still installs and still looks fine, so a missing copy here
+        # would never be noticed - fail loudly instead.
+        $packages = @(
+          @{ Name = "ppt-mcp"; Source = "skills/ppt-mcp"; Target = "packages/ppt-mcp-skill/skills/ppt-mcp" }
+          @{ Name = "ppt-cli"; Source = "skills/ppt-cli"; Target = "packages/ppt-cli-skill/skills/ppt-cli" }
+        )
 
-        # Populate ppt-cli-skill
-        $cliTarget = "packages/ppt-cli-skill/skills/ppt-cli"
-        Get-ChildItem $cliTarget -Exclude ".gitkeep" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
-        Copy-Item "skills/ppt-cli/SKILL.md" $cliTarget
-        Copy-Item "skills/ppt-cli/references" "$cliTarget/references" -Recurse -ErrorAction SilentlyContinue
+        foreach ($pkg in $packages) {
+          $source = $pkg.Source
+          $target = $pkg.Target
+
+          foreach ($required in @("$source/SKILL.md", "$source/references")) {
+            if (-not (Test-Path $required)) {
+              Write-Error "$required is missing - the build did not generate it, so $($pkg.Name) would ship incomplete."
+              exit 1
+            }
+          }
+
+          $referenceCount = @(Get-ChildItem "$source/references" -File -Recurse).Count
+          if ($referenceCount -eq 0) {
+            Write-Error "$source/references is empty - $($pkg.Name) would ship without reference documentation."
+            exit 1
+          }
+
+          New-Item -ItemType Directory -Path $target -Force | Out-Null
+          Get-ChildItem $target -Exclude ".gitkeep" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+
+          Copy-Item "$source/SKILL.md" $target
+          Copy-Item "$source/references" "$target/references" -Recurse
+
+          $copied = @(Get-ChildItem "$target/references" -File -Recurse).Count
+          if ($copied -ne $referenceCount) {
+            Write-Error "Copied $copied of $referenceCount reference files for $($pkg.Name)."
+            exit 1
+          }
+
+          Write-Host "$($pkg.Name): SKILL.md + $copied reference file(s)"
+        }
 
         # Update versions in package.json files
         foreach ($pkg in @("packages/ppt-mcp-skill/package.json", "packages/ppt-cli-skill/package.json")) {


### PR DESCRIPTION
## The problem

The step that fills the two npm skill packages copied the references directory like this:

```powershell
Copy-Item "skills/ppt-mcp/references" "$mcpTarget/references" -Recurse -ErrorAction SilentlyContinue
```

If the build had not produced `skills/ppt-*/references`, the copy was skipped, **the step still reported success**, and npm would have received a package containing only `SKILL.md`. A skill missing its references still installs and still looks correct to a user, so nothing downstream would ever have reported it.

This is the same silent-success pattern that let three of four publish targets be missed in v1.0.3 (#114), and it sits directly in front of the npm publishing we are about to enable.

## The fix

Before copying, the step now verifies that `SKILL.md` and a **non-empty** references directory exist, and afterwards that the copied file count matches the source. Any mismatch fails the job with a message naming the affected skill.

The two packages are also handled by one loop instead of two copy-pasted blocks.

## Deliberately left alone

Auditing the workflow for the same pattern turned up two other suppressions that are correct as they stand:

| Location | Why it stays |
|---|---|
| `Remove-Item $stagingDir -ErrorAction SilentlyContinue` | sits in a `finally` block, where suppressing a secondary cleanup error avoids masking the real exception |
| `catch { "README not yet available" }` in the NuGet propagation poll | a 404 while waiting for CDN propagation is the expected case, not a fault |

## Verification

The step body was extracted from the workflow and run against a sandbox copy of `skills/` and `packages/`:

| Case | Expected | Result |
|---|---|---|
| references present | pass | exit 0 - packaged 6 (ppt-mcp) and 7 (ppt-cli) reference files |
| references directory missing | fail | exit 1 - *"skills/ppt-cli/references is missing - the build did not generate it, so ppt-cli would ship incomplete."* |
| references directory empty | fail | exit 1 - *"skills/ppt-cli/references is empty - ppt-cli would ship without reference documentation."* |

YAML re-parsed successfully (10 jobs). All nine pre-commit gates pass.
