### PR TITLE
fix: turn the default-Windows VBA trust failure into an actionable precondition (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **VBA operations failed with an unactionable COM error when the Trust Center setting was off** (#130): "Trust access to the VBA project object model" is disabled on a default Windows install, so the first `vba` action of a session — including read-only `list` — failed with a raw `COMException` naming neither the cause nor the fix. An agent receiving that message had no path forward and would retry indefinitely or conclude VBA was unsupported.
+  - New `vba check-trust` action (available identically on the CLI and the MCP server) reports `trustEnabled`, the registry location consulted, and the remediation steps — without provoking a failure first
+  - All four `Presentation.VBProject` call sites now route through a guard that converts the failure into `VbaTrustException`, whose message carries the full remediation. The catch is **filtered on the registry probe**, not on an HRESULT or message text: the COM message is localized, and matching a single HRESULT would mislabel unrelated COM failures as trust problems. When trust is enabled the filter is false and the original exception propagates untouched
+  - The remediation states the ordering trap explicitly: writing `AccessVBOM` while PowerPoint is running is silently reverted to 0 on exit, so the value must be set with PowerPoint closed
+  - `skills/shared/behavioral-rules.md` now instructs agents to check trust before the first VBA action and not to retry, since the failure is a configuration state rather than a transient error
+
 - **Pre-commit launched PowerPoint on every commit, including commits that could not affect it**: the CLI workflow test and the MCP smoke test both start a real PowerPoint instance, and both ran unconditionally. A run of documentation edits or `--amend`s would launch PowerPoint several times within a minute against byte-identical source, where every run after the first was guaranteed to reproduce the previous result.
   - Both gates are now keyed on the staged content of `src/` and `scripts/Test-CliWorkflow.ps1`, fingerprinted via `git ls-files -s` and recorded in `.git/pptmcp-smoke-cache` on success. Unchanged content skips them with an explicit message
   - Keyed on **content, not elapsed time**, so it cannot mask a regression: any edit under `src/` yields a different fingerprint and both gates run again. If the fingerprint cannot be computed the gates run, failing open

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # PptMcp - Complete Feature Reference
 
-**33 specialized tools with 223 operations for comprehensive PowerPoint automation**
+**33 specialized tools with 224 operations for comprehensive PowerPoint automation**
 
 > Generated from the source of truth: the action enums emitted by the source generators
 > (`ServiceRegistry.*.g.cs`) plus the hand-written `file` tool. Do not edit counts by hand.
@@ -450,7 +450,7 @@ MCP tool / CLI command: `printoptions`
 
 ---
 
-## ⚙️ VBA Macros Operations (5 operations)
+## ⚙️ VBA Macros Operations (6 operations)
 
 MCP tool / CLI command: `vba`
 
@@ -459,6 +459,7 @@ MCP tool / CLI command: `vba`
 - `import`
 - `delete`
 - `run`
+- `check-trust`
 
 ---
 
@@ -511,9 +512,9 @@ MCP tool / CLI command: `window`
 | `proofing` | 3 |
 | `export` | 9 |
 | `printoptions` | 2 |
-| `vba` | 5 |
+| `vba` | 6 |
 | `window` | 7 |
-| **Total (33 tools)** | **223** |
+| **Total (33 tools)** | **224** |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For multi-phase build / verify / repair workflows from source, the repo also inc
 
 ## 🎯 What You Can Do
 
-**33 specialized tools with 223 operations:**
+**33 specialized tools with 224 operations:**
 
 - 📁 **Files** (1 tool, 6 ops) — Open, close, create, save, list, validate presentations
 - 📄 **Slides** (1 tool, 15 ops) — Create, duplicate, move, delete, apply layouts, hide/unhide, thumbnails, clone-with-replace
@@ -66,7 +66,7 @@ For multi-phase build / verify / repair workflows from source, the repo also inc
 - ⚙️ **VBA** (1 tool, 5 ops) — List, view, import, delete, run macros
 - 🪟 **Window** (1 tool, 7 ops) — Info, minimize, restore, maximize, zoom, view mode
 
-📚 **[Complete Feature Reference →](FEATURES.md)** — Detailed documentation of all 223 operations
+📚 **[Complete Feature Reference →](FEATURES.md)** — Detailed documentation of all 224 operations
 
 
 ## 💬 Example Prompts

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -13,7 +13,7 @@ PowerPoint MCP Server lets you automate PowerPoint through conversation with Cla
 - **Automate** - VBA macros, batch operations
 - **Agent Mode** - Say "show me PowerPoint" and watch AI work in real-time, side-by-side with Claude
 
-**33 tools with 223 operations** for comprehensive PowerPoint automation.
+**33 tools with 224 operations** for comprehensive PowerPoint automation.
 
 ## Requirements
 

--- a/skills/ppt-cli/SKILL.md
+++ b/skills/ppt-cli/SKILL.md
@@ -757,7 +757,7 @@ Slide transition effects: get, set, remove.
 
 VBA macro operations: list modules, view/import/delete code, run macros. Requires VBA trust settings enabled in PowerPoint.
 
-**Actions:** `list`, `view`, `import`, `delete`, `run`
+**Actions:** `list`, `view`, `import`, `delete`, `run`, `check-trust`
 
 | Parameter | Description |
 |-----------|-------------|

--- a/skills/ppt-cli/references/behavioral-rules.md
+++ b/skills/ppt-cli/references/behavioral-rules.md
@@ -231,6 +231,21 @@ Call `file(action: 'close', save: true)` to persist changes:
 
 ## Error Handling Rules
 
+### Check VBA Trust Before Any VBA Action
+
+"Trust access to the VBA project object model" is **disabled by default on Windows**.
+While it is off, every `vba` action fails — including `list`, which otherwise looks
+like a harmless read.
+
+Call `vba(action: 'check-trust')` before the first VBA action in a session:
+
+- `trustEnabled: true` → proceed normally
+- `trustEnabled: false` → the `remediation` field holds the exact steps; relay them
+  to the user and stop. This is a machine setting; it cannot be fixed from the tools.
+
+Do not retry a failed VBA action without checking trust first. The failure is a
+configuration state, not a transient error, so retrying will fail identically.
+
 ### Interpret Error Messages
 
 PowerPoint MCP errors include actionable context:

--- a/skills/ppt-mcp/SKILL.md
+++ b/skills/ppt-mcp/SKILL.md
@@ -9,7 +9,7 @@ description: >
 
 # PowerPoint MCP Server Skill
 
-Provides 218 PowerPoint operations via Model Context Protocol. The MCP Server forwards all requests to the shared PptMcp Service, enabling session sharing with CLI. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
+Provides 219 PowerPoint operations via Model Context Protocol. The MCP Server forwards all requests to the shared PptMcp Service, enabling session sharing with CLI. Tools are auto-discovered - this documents quirks, workflows, and gotchas.
 
 ## Workflow Checklist
 

--- a/skills/ppt-mcp/references/behavioral-rules.md
+++ b/skills/ppt-mcp/references/behavioral-rules.md
@@ -231,6 +231,21 @@ Call `file(action: 'close', save: true)` to persist changes:
 
 ## Error Handling Rules
 
+### Check VBA Trust Before Any VBA Action
+
+"Trust access to the VBA project object model" is **disabled by default on Windows**.
+While it is off, every `vba` action fails — including `list`, which otherwise looks
+like a harmless read.
+
+Call `vba(action: 'check-trust')` before the first VBA action in a session:
+
+- `trustEnabled: true` → proceed normally
+- `trustEnabled: false` → the `remediation` field holds the exact steps; relay them
+  to the user and stop. This is a machine setting; it cannot be fixed from the tools.
+
+Do not retry a failed VBA action without checking trust first. The failure is a
+configuration state, not a transient error, so retrying will fail identically.
+
 ### Interpret Error Messages
 
 PowerPoint MCP errors include actionable context:

--- a/skills/shared/behavioral-rules.md
+++ b/skills/shared/behavioral-rules.md
@@ -231,6 +231,21 @@ Call `file(action: 'close', save: true)` to persist changes:
 
 ## Error Handling Rules
 
+### Check VBA Trust Before Any VBA Action
+
+"Trust access to the VBA project object model" is **disabled by default on Windows**.
+While it is off, every `vba` action fails — including `list`, which otherwise looks
+like a harmless read.
+
+Call `vba(action: 'check-trust')` before the first VBA action in a session:
+
+- `trustEnabled: true` → proceed normally
+- `trustEnabled: false` → the `remediation` field holds the exact steps; relay them
+  to the user and stop. This is a machine setting; it cannot be fixed from the tools.
+
+Do not retry a failed VBA action without checking trust first. The failure is a
+configuration state, not a transient error, so retrying will fail identically.
+
 ### Interpret Error Messages
 
 PowerPoint MCP errors include actionable context:

--- a/src/PptMcp.CLI/README.md
+++ b/src/PptMcp.CLI/README.md
@@ -8,7 +8,7 @@
 
 > **Published as its own .NET tool** - Install `PptMcp.CLI` to get the `pptcli` command. Install `PptMcp.McpServer` separately when you also need the MCP server (`mcp-ppt`).
 
-The CLI provides 33 command categories with 223 operations matching the MCP Server. Uses **64% fewer tokens** than MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 33 tool schemas into context.
+The CLI provides 33 command categories with 224 operations matching the MCP Server. Uses **64% fewer tokens** than MCP Server because it wraps all operations in a single tool with skill-based guidance instead of loading 33 tool schemas into context.
 
 | Interface | Best For | Why |
 |-----------|----------|-----|
@@ -102,7 +102,7 @@ Descriptions are kept in sync with the CLI source so the help output always refl
 
 ## 📋 Command Categories
 
-PptMcp.CLI provides **223 operations** across 33 command categories:
+PptMcp.CLI provides **224 operations** across 33 command categories:
 
 📚 **[Complete Feature Reference →](../../FEATURES.md)** - Full documentation with all operations
 

--- a/src/PptMcp.Core/Commands/Vba/IVbaCommands.cs
+++ b/src/PptMcp.Core/Commands/Vba/IVbaCommands.cs
@@ -52,4 +52,14 @@ public interface IVbaCommands
     /// <param name="macroName">Fully qualified macro name (e.g., "Module1.MyMacro")</param>
     [ServiceAction("run")]
     OperationResult Run(IPptBatch batch, string macroName);
+
+    /// <summary>
+    /// Report whether "Trust access to the VBA project object model" is enabled.
+    /// Use this before other VBA actions: the setting is disabled by default on
+    /// Windows, and when it is off every other action in this tool fails.
+    /// Returns the remediation steps when trust is disabled.
+    /// </summary>
+    /// <param name="batch">Batch context</param>
+    [ServiceAction("check-trust")]
+    VbaTrustResult CheckTrust(IPptBatch batch);
 }

--- a/src/PptMcp.Core/Commands/Vba/VbaCommands.cs
+++ b/src/PptMcp.Core/Commands/Vba/VbaCommands.cs
@@ -1,17 +1,72 @@
+using System.Runtime.InteropServices;
 using PptMcp.ComInterop;
 using PptMcp.ComInterop.Session;
+using PptMcp.Core.Diagnostics;
 using PptMcp.Core.Models;
 
 namespace PptMcp.Core.Commands.Vba;
 
 public class VbaCommands : IVbaCommands
 {
+    /// <summary>
+    /// Acquires the VBA project, converting the default-Windows trust failure into
+    /// actionable remediation (issue #130).
+    ///
+    /// The catch is filtered on the probe rather than on an HRESULT or message text.
+    /// Matching the message would break on non-English Office, and matching a single
+    /// HRESULT risks labelling unrelated COM failures as a trust problem. Consulting
+    /// the setting itself answers the question directly.
+    ///
+    /// When trust IS enabled the filter is false, so the original exception propagates
+    /// untouched to <c>batch.Execute()</c> exactly as before - this guard can only add
+    /// information, never swallow a different fault.
+    /// </summary>
+    private static dynamic GetVbProject(dynamic pres)
+    {
+        try
+        {
+            return pres.VBProject;
+        }
+        catch (COMException ex) when (!VbaTrustProbe.IsTrustEnabled())
+        {
+            // Rule 1b: route a specific error, do not synthesise a result. The typed
+            // exception propagates to batch.Execute(), which builds the
+            // OperationResult at the correct layer.
+            throw new VbaTrustException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Reports whether VBA trust is enabled, without attempting a VBA operation.
+    ///
+    /// Exists so an agent can establish the precondition before it hits the failure,
+    /// rather than having to provoke an error and interpret it. Rides the generated
+    /// tool surface, so it is available on the CLI and the MCP server identically.
+    /// </summary>
+    public VbaTrustResult CheckTrust(IPptBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        // Deliberately not inside batch.Execute(): the answer comes from the registry,
+        // not from the presentation, and it must remain obtainable when the COM call
+        // that needs it would itself fail.
+        var enabled = VbaTrustProbe.IsTrustEnabled();
+
+        return new VbaTrustResult
+        {
+            Success = true,
+            TrustEnabled = enabled,
+            RegistryPath = VbaTrustProbe.DescribeRegistryPath(),
+            Remediation = enabled ? string.Empty : VbaTrustProbe.RemediationText
+        };
+    }
+
     public VbaModuleListResult List(IPptBatch batch)
     {
         return batch.Execute((ctx, ct) =>
         {
             dynamic pres = (dynamic)ctx.Presentation;
-            dynamic vbProject = pres.VBProject;
+            dynamic vbProject = GetVbProject(pres);
             dynamic components = vbProject.VBComponents;
             try
             {
@@ -62,7 +117,7 @@ public class VbaCommands : IVbaCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic pres = (dynamic)ctx.Presentation;
-            dynamic vbProject = pres.VBProject;
+            dynamic vbProject = GetVbProject(pres);
             dynamic components = vbProject.VBComponents;
             dynamic comp = components.Item(moduleName);
             dynamic? codeModule = null;
@@ -101,7 +156,7 @@ public class VbaCommands : IVbaCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic pres = (dynamic)ctx.Presentation;
-            dynamic vbProject = pres.VBProject;
+            dynamic vbProject = GetVbProject(pres);
             dynamic components = vbProject.VBComponents;
             dynamic? comp = null;
             dynamic? codeModule = null;
@@ -139,7 +194,7 @@ public class VbaCommands : IVbaCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic pres = (dynamic)ctx.Presentation;
-            dynamic vbProject = pres.VBProject;
+            dynamic vbProject = GetVbProject(pres);
             dynamic components = vbProject.VBComponents;
             dynamic comp = components.Item(moduleName);
             try

--- a/src/PptMcp.Core/Diagnostics/VbaTrustException.cs
+++ b/src/PptMcp.Core/Diagnostics/VbaTrustException.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace PptMcp.Core.Diagnostics;
+
+/// <summary>
+/// Raised when a VBA operation fails because "Trust access to the VBA project object
+/// model" is disabled.
+///
+/// Carries the remediation in its message so the text reaches the caller through the
+/// normal failure path. Both entry points surface an exception's message: the CLI
+/// prints it, and <c>batch.Execute()</c> turns it into
+/// <c>OperationResult { Success = false, ErrorMessage }</c> for MCP. Nothing extra is
+/// needed at either layer for the advice to arrive.
+///
+/// Note deliberately NOT thrown from a bare <c>catch (Exception)</c>. It is raised
+/// only after <see cref="VbaTrustProbe"/> confirms the setting is actually disabled,
+/// so an unrelated COM failure is never mislabelled as a trust problem.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class VbaTrustException : InvalidOperationException
+{
+    /// <summary>Creates the exception with the standard remediation text.</summary>
+    /// <param name="inner">The original COM failure, preserved for diagnostics.</param>
+    public VbaTrustException(Exception? inner)
+        : base(BuildMessage(inner), inner)
+    {
+    }
+
+    /// <summary>Creates the exception with the standard remediation text.</summary>
+    public VbaTrustException()
+        : base(BuildMessage(null))
+    {
+    }
+
+    /// <summary>Creates the exception with a caller-supplied message.</summary>
+    /// <param name="message">Message to use instead of the standard remediation.</param>
+    public VbaTrustException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Creates the exception with a caller-supplied message and inner exception.</summary>
+    /// <param name="message">Message to use instead of the standard remediation.</param>
+    /// <param name="innerException">The original failure.</param>
+    public VbaTrustException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>The registry state observed when the failure was diagnosed.</summary>
+    public string RegistryPath { get; } = VbaTrustProbe.DescribeRegistryPath();
+
+    private static string BuildMessage(Exception? inner)
+    {
+        var original = inner is COMException com
+            ? $" (original COM error 0x{com.HResult:X8}: {com.Message})"
+            : inner is not null ? $" (original error: {inner.Message})" : string.Empty;
+
+        return $"{VbaTrustProbe.RemediationText} Observed: {VbaTrustProbe.DescribeRegistryPath()}.{original}";
+    }
+}

--- a/src/PptMcp.Core/Diagnostics/VbaTrustProbe.cs
+++ b/src/PptMcp.Core/Diagnostics/VbaTrustProbe.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace PptMcp.Core.Diagnostics;
+
+/// <summary>
+/// Determines whether "Trust access to the VBA project object model" is enabled, and
+/// supplies the remediation text for when it is not.
+///
+/// This exists because the precondition is disabled on a default Windows install, so
+/// every VBA operation fails on first use with a raw <see cref="COMException"/> whose
+/// message names neither the cause nor the fix (issue #130). An agent that receives
+/// that message has no path forward and will either retry indefinitely or conclude
+/// that VBA is unsupported.
+///
+/// The probe reads the registry rather than matching on the exception's HRESULT or
+/// message. Both alternatives are unreliable: the message is localized, and matching
+/// a single HRESULT risks reporting unrelated COM failures as a trust problem. The
+/// registry value is the setting itself, so consulting it answers the question
+/// directly and in a locale-independent way.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public static class VbaTrustProbe
+{
+    private const string OfficeRoot = @"Software\Microsoft\Office";
+    private const string SecuritySuffix = @"PowerPoint\Security";
+    private const string ValueName = "AccessVBOM";
+
+    /// <summary>
+    /// Human-readable remediation naming every step the caller cannot infer: the key,
+    /// the value, the restart requirement, and the ordering trap.
+    ///
+    /// The ordering matters and is easy to get wrong. Writing the value while
+    /// PowerPoint is running appears to succeed, but PowerPoint rewrites its Security
+    /// key on exit and silently reverts it to 0 - so the obvious sequence (set the
+    /// value, then restart) leaves the setting exactly as it was.
+    /// </summary>
+    public static string RemediationText { get; } =
+        "VBA operations require 'Trust access to the VBA project object model', which is " +
+        "disabled by default on Windows. To enable it: " +
+        "(1) close PowerPoint completely - setting the value while PowerPoint is running " +
+        "is silently reverted to 0 when it exits; " +
+        @"(2) set HKCU\Software\Microsoft\Office\<version>\PowerPoint\Security\AccessVBOM " +
+        "(DWORD) to 1, where <version> is your Office version such as 16.0; " +
+        "(3) restart PowerPoint - the setting is read only at process start. " +
+        "The equivalent UI path is File > Options > Trust Center > Trust Center Settings > " +
+        "Macro Settings > Trust access to the VBA project object model.";
+
+    /// <summary>
+    /// Returns true when any installed Office version has <c>AccessVBOM</c> set to 1.
+    ///
+    /// Any version is sufficient because a machine with several Office versions
+    /// registered will drive whichever one PowerPoint actually launched, and this
+    /// probe has no reliable way to know which that is. Reporting "enabled" when at
+    /// least one is enabled is the conservative direction: it never invents a trust
+    /// problem that would send the caller to change a setting that is already correct.
+    /// </summary>
+    public static bool IsTrustEnabled()
+    {
+        foreach (var entry in ReadAllTrustValues())
+        {
+            if (entry.Value == 1)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the registry path this probe consulted, for inclusion in results so the
+    /// caller can verify the diagnosis rather than take it on trust.
+    /// </summary>
+    public static string DescribeRegistryPath()
+    {
+        var found = ReadAllTrustValues();
+
+        if (found.Count == 0)
+        {
+            return $@"HKCU\{OfficeRoot}\<version>\{SecuritySuffix}\{ValueName} (no Office version found)";
+        }
+
+        var parts = found.Select(f =>
+        {
+            var shown = f.Value.HasValue
+                ? f.Value.Value.ToString(CultureInfo.InvariantCulture)
+                : "(not set)";
+            return $@"HKCU\{OfficeRoot}\{f.Version}\{SecuritySuffix}\{ValueName}={shown}";
+        });
+
+        return string.Join("; ", parts);
+    }
+
+    /// <summary>
+    /// Enumerates every installed Office version key and reads its AccessVBOM value.
+    ///
+    /// Tolerates a partial or unusual Office layout by design. Real machines carry
+    /// stray version keys - an "8.0" with no PowerPoint subkey is common - and this
+    /// method runs inside an error path, where throwing would replace a useful
+    /// diagnosis with a second, less informative failure.
+    /// </summary>
+    private static List<(string Version, int? Value)> ReadAllTrustValues()
+    {
+        var results = new List<(string Version, int? Value)>();
+
+        try
+        {
+            using var office = Registry.CurrentUser.OpenSubKey(OfficeRoot);
+
+            if (office is null)
+            {
+                return results;
+            }
+
+            foreach (var versionName in office.GetSubKeyNames())
+            {
+                // Office version keys are numeric ("16.0"). Skip named subkeys such as
+                // "Common" or "ClickToRun", which have no PowerPoint security settings.
+                if (!IsVersionKey(versionName))
+                {
+                    continue;
+                }
+
+                using var security = office.OpenSubKey($@"{versionName}\{SecuritySuffix}");
+
+                if (security is null)
+                {
+                    continue;
+                }
+
+                var raw = security.GetValue(ValueName);
+                results.Add((versionName, raw is int i ? i : null));
+            }
+        }
+        catch (Exception ex) when (ex is System.Security.SecurityException or UnauthorizedAccessException or IOException)
+        {
+            // A caller without read access to HKCU cannot be diagnosed, but must still
+            // receive the original COM failure rather than a registry exception layered
+            // on top of it. Returning empty means "unknown", which callers treat as
+            // "not proven enabled".
+        }
+
+        return results;
+    }
+
+    private static bool IsVersionKey(string name)
+    {
+        return name.Length > 0 && char.IsDigit(name[0]);
+    }
+}

--- a/src/PptMcp.Core/Models/ResultTypes.cs
+++ b/src/PptMcp.Core/Models/ResultTypes.cs
@@ -318,6 +318,22 @@ public class VbaModuleCodeResult : ResultBase
     public int LineCount { get; set; }
 }
 
+/// <summary>
+/// Whether "Trust access to the VBA project object model" is enabled, plus the
+/// remediation when it is not.
+/// </summary>
+public class VbaTrustResult : ResultBase
+{
+    /// <summary>True when the setting is enabled and VBA actions can run.</summary>
+    public bool TrustEnabled { get; set; }
+
+    /// <summary>The registry location(s) consulted, so the diagnosis can be verified.</summary>
+    public string RegistryPath { get; set; } = string.Empty;
+
+    /// <summary>Steps to enable trust. Empty when trust is already enabled.</summary>
+    public string Remediation { get; set; } = string.Empty;
+}
+
 // ── Window ────────────────────────────────────────────────
 
 public class WindowInfoResult : ResultBase

--- a/src/PptMcp.McpServer/README.md
+++ b/src/PptMcp.McpServer/README.md
@@ -55,7 +55,7 @@ dotnet tool install --global PptMcp.CLI
 
 ## 🛠️ What You Can Do
 
-**33 specialized tools with 223 operations:**
+**33 specialized tools with 224 operations:**
 
 - 📁 **Files** (1 tool, 6 ops) - Session management, open/create/save/close presentations
 - 📄 **Slides** (1 tool, 15 ops) - Lifecycle, layouts, hide/unhide, thumbnails, clone-with-replace
@@ -91,7 +91,7 @@ dotnet tool install --global PptMcp.CLI
 - ⚙️ **VBA** (1 tool, 5 ops) - Modules, import, execution
 - 🪟 **Window Management** (1 tool, 7 ops) - Show/arrange PowerPoint, zoom, view mode
 
-📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 223 operations
+📚 **[Complete Feature Reference →](../../FEATURES.md)** - Detailed documentation of all 224 operations
 
 **AI-Powered Workflows:**
 - 💬 Natural language PowerPoint commands through GitHub Copilot, Claude, or ChatGPT

--- a/tests/PptMcp.Core.Tests/Integration/VbaTrustTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/VbaTrustTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Vba;
+using PptMcp.Core.Diagnostics;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Covers the VBA trust precondition (issue #130).
+///
+/// "Trust access to the VBA project object model" is disabled on a default Windows
+/// install, so every VBA operation fails on first use with a raw COMException whose
+/// message names no cause and no fix. These tests cover the diagnostic path that
+/// turns that into actionable text.
+///
+/// Deliberately does NOT toggle the registry value. Doing so would mutate machine
+/// state shared with the developer's own PowerPoint, and - as issue #130 documents -
+/// the value is silently reverted to 0 if PowerPoint is running when it is written.
+/// The disabled branch is covered by asserting on the remediation text itself, which
+/// is a pure function of the probe result.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "VbaTrust")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class VbaTrustTests : IClassFixture<TempDirectoryFixture>
+{
+    private readonly TempDirectoryFixture _fixture;
+    private readonly VbaCommands _commands = new();
+
+    public VbaTrustTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void CheckTrust_ReportsTheLiveRegistryState()
+    {
+        var filePath = _fixture.CreateTestFile(extension: ".pptm");
+
+        using var batch = PptSession.BeginBatch(filePath);
+        var result = _commands.CheckTrust(batch);
+
+        Assert.True(result.Success);
+
+        // The probe must agree with the registry it claims to read, whichever way the
+        // machine is configured. Asserting a fixed value would make this test pass or
+        // fail on the developer's Trust Center setting rather than on the code.
+        Assert.Equal(VbaTrustProbe.IsTrustEnabled(), result.TrustEnabled);
+
+        Assert.False(string.IsNullOrWhiteSpace(result.RegistryPath));
+        Assert.Contains("AccessVBOM", result.RegistryPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CheckTrust_WhenTrustDisabled_CarriesRemediation()
+    {
+        var filePath = _fixture.CreateTestFile(extension: ".pptm");
+
+        using var batch = PptSession.BeginBatch(filePath);
+        var result = _commands.CheckTrust(batch);
+
+        if (result.TrustEnabled)
+        {
+            // Trust is on, so there is nothing to remediate and the field must be empty
+            // rather than carrying stale advice.
+            Assert.True(string.IsNullOrEmpty(result.Remediation));
+            return;
+        }
+
+        Assert.False(string.IsNullOrWhiteSpace(result.Remediation));
+    }
+
+    [Fact]
+    public void VbaOperation_WhenTrustDisabled_SurfacesRemediationNotRawComException()
+    {
+        if (VbaTrustProbe.IsTrustEnabled())
+        {
+            // Cannot exercise the failure path without disabling trust machine-wide,
+            // which this suite refuses to do. The remediation text itself is asserted
+            // below in RemediationText_NamesRegistryPathValueAndRestart.
+            return;
+        }
+
+        var filePath = _fixture.CreateTestFile(extension: ".pptm");
+
+        using var batch = PptSession.BeginBatch(filePath);
+
+        var ex = Assert.ThrowsAny<Exception>(() => _commands.List(batch));
+
+        // The whole point of #130: the caller must not receive a bare COMException.
+        Assert.IsNotType<COMException>(ex);
+        Assert.Contains("AccessVBOM", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("restart", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RemediationText_NamesRegistryPathValueAndRestart()
+    {
+        var text = VbaTrustProbe.RemediationText;
+
+        // An agent that hits this error has only this string to act on. Each element
+        // below is a step it cannot infer: the key, the value, and the fact that
+        // PowerPoint reads the setting only at process start.
+        Assert.Contains("AccessVBOM", text, StringComparison.Ordinal);
+        Assert.Contains("PowerPoint\\Security", text, StringComparison.Ordinal);
+        Assert.Contains("1", text, StringComparison.Ordinal);
+        Assert.Contains("restart", text, StringComparison.OrdinalIgnoreCase);
+
+        // Setting the value while PowerPoint is running is silently reverted on exit,
+        // so the order of operations has to be stated or the fix appears not to work.
+        Assert.Contains("running", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsTrustEnabled_DoesNotThrow_RegardlessOfOfficeLayout()
+    {
+        // Office version keys vary by install, and a stray key such as "8.0" with no
+        // PowerPoint\Security subkey exists on real machines. The probe must tolerate
+        // that rather than throw, since it runs inside an error path.
+        var ex = Record.Exception(() => VbaTrustProbe.IsTrustEnabled());
+        Assert.Null(ex);
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -16,7 +16,7 @@
 
 ## Features
 
-The PowerPoint MCP Server (ppt-mcp) provides **33 specialized tools with 223 operations** for comprehensive PowerPoint automation:
+The PowerPoint MCP Server (ppt-mcp) provides **33 specialized tools with 224 operations** for comprehensive PowerPoint automation:
 
 - 📁 **Files** (1 tool, 6 ops) - Session management, presentation creation, IRM/AIP-protected file support
 - 📄 **Slides** (1 tool, 15 ops) - Lifecycle, layouts, hide/unhide, thumbnails


### PR DESCRIPTION
Closes #130.

## The problem

"Trust access to the VBA project object model" is disabled on a default Windows install. Every `vba` action — including read-only `list` — therefore failed on first use with a raw `COMException` naming neither the cause nor the fix.

An agent receiving that message has no path forward. It retries indefinitely, or concludes VBA is unsupported. The failure is a configuration state, so retrying fails identically every time.

## What changed

**`vba check-trust`** — a new action that reports `trustEnabled`, the registry location consulted, and the remediation, **without provoking a failure first**. It rides `IVbaCommands`, so the CLI and MCP server generate it identically and Rule 24 parity is structural rather than hand-maintained.

**Guarded `VBProject` access** — all four call sites route through a guard that converts the failure into `VbaTrustException`, whose message carries the remediation. Both entry points already surface an exception's message, so nothing extra was needed at either layer for the advice to arrive.

## Why the catch is filtered on the registry, not on the error

The obvious implementations are both wrong:

- **Matching the message** breaks on non-English Office — the COM message is localized.
- **Matching a single HRESULT** would report unrelated COM failures as trust problems.

Reading `HKCU\Software\Microsoft\Office\<version>\PowerPoint\Security\AccessVBOM` consults the setting *itself*, so it answers the question directly and locale-independently.

The filter is `when (!VbaTrustProbe.IsTrustEnabled())`. When trust **is** enabled the filter is false and the original exception propagates untouched — this guard can only add information, never swallow a different fault.

Per **Rule 1b** it rethrows a typed exception rather than synthesising an `OperationResult`, leaving `batch.Execute()` to build the result at the correct layer. (The issue's acceptance criteria asked for the `catch → return Success = false` shape, which Rule 1b lists as the pattern to remove; this was raised on the issue before implementing.)

## The ordering trap

Writing `AccessVBOM` while PowerPoint is running appears to succeed, but PowerPoint rewrites its Security key on exit and silently reverts it to 0. The obvious sequence — set the value, then restart — leaves the setting exactly as it was. The remediation states this explicitly.

## Tests

Written first, confirmed RED (`PptMcp.Core.Diagnostics` did not exist).

They deliberately **do not toggle the registry** — that would mutate machine state shared with the developer's own PowerPoint, and per **Rule 30** a mocked alternative would prove nothing. Instead:

- the live-state test agrees with the probe *whichever way the machine is configured*, so it never fails on someone's Trust Center setting;
- the disabled branch is covered by asserting the remediation text, which is a pure function of the probe.

That last assertion earned its place on the first run: it **failed**, because the text said "start PowerPoint again" and never contained `restart` — the word an agent would actually search for. A test that only checked "some remediation is present" would have passed on text that was missing the step.

## Verification

| Gate | Result |
|---|---|
| Release build | 0 warnings / 0 errors |
| `Feature=VbaTrust` | 5/5 |
| SkillGeneration | 11/11 |
| `check-documented-counts` | 33 tools / **224** operations, 11 counts match |
| `check-com-leaks` | 33 clean / 0 leaks |
| `check-inline-com-chains` | 173, at baseline |
| `check-success-flag` | clean |
| `check-test-filters` | 4/4 resolve |
| `check-xunit-parallelization` | 4/4 |

Rule 24 sync: `FEATURES.md` (count, per-tool table, action list), all five READMEs, and `skills/shared/behavioral-rules.md`, which now tells agents to check trust before the first VBA action and **not** to retry.
