### PR TITLE
Refuse unfiltered PowerPoint test runs instead of merely discouraging them

### DIFF
--- a/.github/instructions/critical-rules.instructions.md
+++ b/.github/instructions/critical-rules.instructions.md
@@ -547,6 +547,37 @@ resolves to zero tests. **Before inventing a filter, check the trait exists** - 
 current list is in [testing-strategy.instructions.md](testing-strategy.instructions.md)
 and in `tests/README.md`.
 
+### An unfiltered run of a PowerPoint suite is REFUSED, not merely discouraged
+
+Every one of these suites creates a PowerPoint instance **per test**, so
+`dotnet test tests\PptMcp.ComInterop.Tests` with no filter launches POWERPNT once per
+test, back to back, with no upper bound and no timeout. Running the same operation a
+hundred times in a row produces no information the first run did not already give you -
+it just seizes the machine and thrashes the COM layer.
+
+Advisory wording did not stop this happening repeatedly, so the wrapper now enforces it:
+
+```powershell
+# REFUSED - exits 1 before dotnet is ever invoked
+.\scripts\Invoke-GuardedTest.ps1 -Project tests\PptMcp.ComInterop.Tests
+
+# Correct - name what you changed
+.\scripts\Invoke-GuardedTest.ps1 -Project tests\PptMcp.ComInterop.Tests -Filter "RunType=OnDemand"
+
+# Deliberate whole-assembly run (CI does this) - opt in explicitly
+.\scripts\Invoke-GuardedTest.ps1 -Project tests\PptMcp.CLI.Tests -Full
+```
+
+The wrapper additionally:
+- **Timeboxes every run** (`-TimeoutMinutes`, default 20) and kills it on expiry. A hung
+  suite keeps spawning PowerPoint for as long as nobody is watching - see issue #139,
+  where `ComInterop.Tests` does not terminate as a full assembly.
+- **Cleans up PowerPoint processes the run leaked**, while leaving alone any POWERPNT
+  PID that already existed when the run started. Your own open presentation is safe.
+
+**Never invoke `dotnet test` directly on a PowerPoint-driving project** - it bypasses all
+of the above.
+
 **Why Critical:** Integration tests require PowerPoint COM automation and are SLOW. Running all tests wastes time and resources.
 
 **Enforcement:**

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,6 +91,7 @@ jobs:
         run: >
           ./scripts/Invoke-GuardedTest.ps1
           -Project tests/PptMcp.CLI.Tests/PptMcp.CLI.Tests.csproj
+          -Full
           -LoggerFileName cli-integration.trx
 
       - name: Run MCP integration suite
@@ -98,6 +99,7 @@ jobs:
         run: >
           ./scripts/Invoke-GuardedTest.ps1
           -Project tests/PptMcp.McpServer.Tests/PptMcp.McpServer.Tests.csproj
+          -Full
           -LoggerFileName mcp-integration.trx
 
       - name: Run OnDemand COM/session suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`Invoke-GuardedTest.ps1` could not stop a run from launching PowerPoint hundreds of times**: the wrapper failed on zero-match filters but was otherwise indifferent to how much work it started. An unfiltered `dotnet test` on any COM suite creates a PowerPoint instance per test — dozens to hundreds of consecutive launches, with no timeout and no cleanup. Rule 16 already forbade this in prose, and prose did not hold.
+  - **Unfiltered runs of PowerPoint-driving projects are now refused**, exiting 1 before `dotnet` is invoked at all. A whole-assembly run is still possible, but requires the explicit `-Full` opt-in that CI now passes
+  - **Every run is timeboxed** (`-TimeoutMinutes`, default 20) and killed on expiry. Without this, a suite that does not terminate — `ComInterop.Tests` as a full assembly, issue #139 — keeps spawning PowerPoint for as long as nobody is watching
+  - **PowerPoint processes leaked by the run are cleaned up**, matched by PID against a snapshot taken before the run starts, so a developer's own open presentation is never killed
+  - The project allow-list is inverted deliberately: a project is assumed to drive PowerPoint unless named as safe, so a newly added COM suite is guarded on the day it lands rather than the day someone remembers to list it
+
 - **The one tool with no structural CLI/MCP parity guarantee had already diverged** (#131): every other tool is generated from a shared Core interface, so parity holds by construction. Session/file management is hand-written on both entry points — `PptFileTool.cs` says so outright — and it is the bootstrap layer every workflow calls first. MCP exposed a `test` action; the CLI did not, and `FileCommands.Test` was unreachable from the CLI entirely.
   - New `pptcli session test <FILE>` returns the same JSON shape as MCP `file(test)`. It deliberately bypasses the daemon: `FileCommands.Test` is pure file inspection and never launches PowerPoint, so routing it through a pipe would start a daemon to answer a question about the file system — and would make the preflight fail precisely when a preflight is most useful. Exit code 0 when the file is valid, 1 when it is not
   - `src/PptMcp.CLI/README.md` documented a **`file test` command that never existed** on the CLI, and listed the session verbs without `test`. Both corrected

--- a/scripts/Invoke-GuardedTest.ps1
+++ b/scripts/Invoke-GuardedTest.ps1
@@ -1,9 +1,25 @@
-# Runs `dotnet test` and fails when the filter selected no tests.
+# Runs `dotnet test` and refuses to report success without evidence that tests ran.
 #
-# `dotnet test --filter <anything>` prints "No test matches the given testcase filter"
-# and then exits 0, so a filter that selects nothing is indistinguishable from a run
-# where everything passed. Every CI step and every documented workflow that applies a
-# filter must go through this wrapper, or a typo silently turns the step into a no-op.
+# Guards, in the order they bite:
+#
+# 1. UNFILTERED RUNS ARE REFUSED on projects that drive real PowerPoint. Those suites
+#    create a PowerPoint instance per test, so an unfiltered `dotnet test` launches
+#    POWERPNT dozens to hundreds of times back to back. That is not a faster way to
+#    get the same answer - every run after the first tells you nothing new, it just
+#    hammers the developer's machine and the COM layer. Rule 16 already says test only
+#    what you changed; this makes it structural instead of advisory.
+#    Pass -Full to opt in deliberately.
+#
+# 2. A HARD TIMEOUT. tests\PptMcp.ComInterop.Tests does not terminate as a full
+#    assembly (issue #139), and an un-timeboxed hang keeps spawning PowerPoint for as
+#    long as nobody is watching. Nothing here may run unbounded.
+#
+# 3. STRAY POWERPOINT CLEANUP. Only processes that appear DURING the run are killed -
+#    PIDs present beforehand are the developer's own PowerPoint and are left alone.
+#
+# 4. The original guard: `dotnet test --filter <anything>` prints "No test matches the
+#    given testcase filter" and then exits 0, so a filter selecting nothing is
+#    indistinguishable from a run where everything passed.
 #
 # ASCII only - see scripts/check-test-filters.ps1 for why.
 
@@ -20,10 +36,49 @@ param(
 
     [switch]$NoBuild,
 
-    [int]$MinimumTests = 1
+    [int]$MinimumTests = 1,
+
+    # Opt in to running a whole PowerPoint-driving assembly. Required by guard 1.
+    [switch]$Full,
+
+    # Hard ceiling on wall-clock time. Guard 2.
+    [int]$TimeoutMinutes = 20
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Projects that do NOT drive PowerPoint. Everything else is assumed to, because the
+# safe direction for this guard is to over-trigger rather than under-trigger.
+$nonPowerPointProjects = @(
+    'PptMcp.SkillGeneration.Tests'
+)
+
+$projectLeaf = Split-Path $Project -Leaf
+$drivesPowerPoint = $projectLeaf -notin $nonPowerPointProjects
+
+# ---------------------------------------------------------------- guard 1
+if ($drivesPowerPoint -and -not $Filter -and -not $Full) {
+    Write-Host ""
+    Write-Host "REFUSED: unfiltered run of a PowerPoint-driving suite." -ForegroundColor Red
+    Write-Host "         Project: $Project"
+    Write-Host ""
+    Write-Host "These suites create a PowerPoint instance per test, so this would launch"
+    Write-Host "POWERPNT once per test with no upper bound. Rule 16: test only what you"
+    Write-Host "changed."
+    Write-Host ""
+    Write-Host "Use a filter:"
+    Write-Host "  .\scripts\Invoke-GuardedTest.ps1 -Project $Project -Filter 'Feature=Slide'"
+    Write-Host ""
+    Write-Host "If you genuinely want the whole assembly, say so:"
+    Write-Host "  .\scripts\Invoke-GuardedTest.ps1 -Project $Project -Full"
+    Write-Host ""
+    Write-Host "Note: tests\PptMcp.ComInterop.Tests does not terminate as a full assembly"
+    Write-Host "      (issue #139). -Full will hit the timeout there."
+    exit 1
+}
+
+# Snapshot pre-existing PowerPoint so the developer's own instance is never killed.
+$preExistingPids = @(Get-Process POWERPNT -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
 
 $testArgs = @('test', $Project, '-c', $Configuration)
 if ($Filter)         { $testArgs += @('--filter', $Filter) }
@@ -31,12 +86,63 @@ if ($LoggerFileName) { $testArgs += @('--logger', "trx;LogFileName=$LoggerFileNa
 if ($NoBuild)        { $testArgs += '--no-build' }
 
 Write-Host "dotnet $($testArgs -join ' ')"
-$output = & dotnet @testArgs 2>&1
-$testExit = $LASTEXITCODE
-$output | ForEach-Object { Write-Host $_ }
+if ($drivesPowerPoint) {
+    Write-Host "guard: PowerPoint-driving suite, timeout ${TimeoutMinutes}m, $($preExistingPids.Count) pre-existing POWERPNT process(es) protected"
+}
+
+$stdoutFile = [System.IO.Path]::GetTempFileName()
+$stderrFile = [System.IO.Path]::GetTempFileName()
+$timedOut = $false
+$testExit = 1
+$output = @()
+
+try {
+    $proc = Start-Process -FilePath 'dotnet' -ArgumentList $testArgs -NoNewWindow -PassThru `
+        -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
+
+    # ------------------------------------------------------------ guard 2
+    if (-not $proc.WaitForExit($TimeoutMinutes * 60 * 1000)) {
+        $timedOut = $true
+        Write-Host ""
+        Write-Host "TIMEOUT: the run exceeded $TimeoutMinutes minute(s). Killing it." -ForegroundColor Red
+        try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+        Start-Sleep -Seconds 2
+        $testExit = 124
+    }
+    else {
+        $testExit = $proc.ExitCode
+    }
+}
+finally {
+    if (Test-Path $stdoutFile) { $output += Get-Content $stdoutFile }
+    if (Test-Path $stderrFile) { $output += Get-Content $stderrFile }
+    Remove-Item $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+
+    $output | ForEach-Object { Write-Host $_ }
+
+    # ------------------------------------------------------------ guard 3
+    $strays = @(Get-Process POWERPNT -ErrorAction SilentlyContinue |
+        Where-Object { $_.Id -notin $preExistingPids })
+
+    if ($strays.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Cleaning up $($strays.Count) PowerPoint process(es) left behind by this run..." -ForegroundColor Yellow
+        foreach ($p in $strays) {
+            try { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue } catch { }
+        }
+    }
+}
 
 $text = ($output | Out-String)
 
+if ($timedOut) {
+    Write-Host ""
+    Write-Host "FAIL: run timed out after $TimeoutMinutes minute(s) and was killed." -ForegroundColor Red
+    Write-Host "      A hanging suite keeps spawning PowerPoint, so it is never left running."
+    exit 124
+}
+
+# ---------------------------------------------------------------- guard 4
 if ($text -match 'No test matches the given testcase filter') {
     Write-Host ""
     Write-Host "FAIL: the filter selected no tests." -ForegroundColor Red


### PR DESCRIPTION
## The problem

`Invoke-GuardedTest.ps1` failed a run whose filter matched nothing, but was otherwise
indifferent to how much work it started.

Every COM test suite here creates a PowerPoint instance **per test**. So an unfiltered
`dotnet test tests\PptMcp.ComInterop.Tests` launches POWERPNT once per test, back to
back, with no upper bound, no timeout, and no cleanup. Every launch after the first
tells you nothing the first did not - it just seizes the developer's machine and
thrashes the COM layer.

Rule 16 already forbade this, in prose. Prose did not hold: it happened repeatedly.
This makes the rule structural.

## What changed

**1. Unfiltered runs of PowerPoint-driving projects are refused** - exit 1 *before*
`dotnet` is invoked at all.

```
REFUSED: unfiltered run of a PowerPoint-driving suite.
         Project: tests\PptMcp.ComInterop.Tests
```

Whole-assembly runs are still possible; they now require an explicit `-Full`. The two
CI steps that deliberately run whole assemblies pass it.

**2. Every run is timeboxed** (`-TimeoutMinutes`, default 20) and killed on expiry.
Without this, a suite that does not terminate - `ComInterop.Tests` as a full assembly,
issue #139 - keeps spawning PowerPoint for as long as nobody is watching. The wrapper
previously had no timebox of any kind.

**3. PowerPoint processes the run leaked are cleaned up**, matched by PID against a
snapshot taken *before* the run starts. A developer's own open presentation is never
killed.

The project list is inverted deliberately: a project is assumed to drive PowerPoint
unless explicitly named safe. A newly added COM suite is therefore guarded on the day
it lands, not the day someone remembers to add it to a list.

## Verification - performed without launching PowerPoint

| Check | Result |
|---|---|
| Unfiltered `ComInterop.Tests` | REFUSED, exit 1, before process start |
| Unfiltered `Core.Tests` | REFUSED, exit 1, before process start |
| `WaitForExit(timeout)` on an over-running process | returns `False` at the deadline; kill confirmed dead |
| PID-protection set logic | pre-existing PIDs excluded, only the new PID identified as stray |
| Script is ASCII-only | 0 non-ASCII bytes (cp1252 parse-error hazard) |
| Script parses | 0 parse errors |
| Workflow YAML | parses, 13 steps |

The refusal paths are checked by exercising the script itself, not by reasoning about
it - and they exit ahead of any `dotnet` invocation, so verifying them costs zero
PowerPoint launches.

## Docs

Rule 16 in `critical-rules.instructions.md` gains a section stating that an unfiltered
run is refused rather than discouraged, with the correct invocations and a note that
`dotnet test` must never be called directly on a PowerPoint-driving project, since that
bypasses all three guards. CHANGELOG updated per Rule 27.
