### PR TITLE
Re-run only the integration suites a change can affect

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -256,6 +256,7 @@ enforced at push time instead.
 
 ```powershell
 .\scripts\Invoke-LocalIntegrationGate.ps1   # runs the suite, writes the evidence manifest
+.\scripts\Invoke-LocalIntegrationGate.ps1 -ListInputs   # audit suite inputs, runs nothing
 ```
 
 The manifest at `.integration-evidence/manifest.json` (gitignored) is **bound to a commit
@@ -263,6 +264,13 @@ SHA** and records every suite, its test count, and its result. The pre-push hook
 any push touching `src/` or `tests/` without valid evidence for that exact commit.
 Rejected: a missing manifest, a manifest for a different SHA, one produced from a dirty
 tree (`binding=none`), a recorded failure, or any suite reporting zero tests.
+
+**The gate is scope-aware — do not work around it by skipping runs.** Each suite's inputs
+come from its transitive `ProjectReference` closure, fingerprinted with git's own blob
+SHAs. A suite whose inputs are unchanged since the previous manifest is carried forward as
+`reused` (recording the commit it was verified on) instead of re-run. A Core-only change
+skips the entire ComInterop assembly; a docs-only change reuses everything and finishes in
+seconds without launching PowerPoint. Use `-Force` only when you suspect a flaky result.
 
 Override, deliberately and on the record:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ dotnet test tests\PptMcp.Core.Tests -c Release --no-build --filter "Feature=Slid
 
 # Full integration suite + evidence manifest, required before pushing src/ or tests/
 .\scripts\Invoke-LocalIntegrationGate.ps1
+
+# Audit which paths each suite depends on, without running anything
+.\scripts\Invoke-LocalIntegrationGate.ps1 -ListInputs
 ```
 
 **There is no CI for the integration suite, and there will not be.** The
@@ -115,6 +118,13 @@ locally by `Invoke-LocalIntegrationGate.ps1`, which writes an evidence manifest 
 a commit SHA, and the pre-push hook refuses to push `src/` or `tests/` changes without
 evidence for that exact commit. Override with `PPTMCP_SKIP_INTEGRATION_GATE=1`, which
 prints a banner naming the unverified commit.
+
+The gate is **scope-aware**: each suite's inputs are derived from its transitive
+`ProjectReference` closure, and a suite whose inputs are byte-identical to the previous
+manifest is carried forward as `reused` rather than re-run. A Core-only change therefore
+skips the whole ComInterop assembly (96 tests, ~96 PowerPoint launches). Reuse only
+applies when both manifests are `binding=commit`. Pass `-Force` to re-run everything when
+you suspect a flaky result rather than a stale one.
 
 **If the build fails with `MSB3027` (file locked):** a `pptcli` daemon or MSBuild node still holds the output.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The integration gate now re-runs only the suites a change can actually affect** (#143 follow-up): a full gate run is ~11 minutes and launches PowerPoint roughly 200 times, and it ran in full for every push — including pushes that touched only documentation or a single unrelated project. A gate that expensive on every push is a gate that ends up disabled.
+  - Each suite's inputs are now derived from its **transitive `ProjectReference` closure**, not a hand-maintained list, so the mapping cannot silently drift from the build graph. The fingerprint is a SHA-256 over `git ls-files -s` for those paths, which uses git's own blob SHAs as the content hash rather than re-reading files.
+  - A suite whose fingerprint matches the previous manifest is carried forward and marked `reused`, with the commit it was actually verified on recorded in `reusedFrom`. The pushed commit's evidence therefore still names the run that produced it.
+  - Reuse is refused unless the previous manifest and the current run are both `binding=commit`. `git ls-files` reports the index, so on a dirty tree its blob SHAs would describe content that no commit holds — the same reason the gate refuses to mint evidence from a dirty tree at all.
+  - Measured effect: a change confined to `src/PptMcp.Core` now reuses `cominterop-full`, skipping 96 tests and ~96 PowerPoint launches, while every suite that genuinely depends on Core still runs. A docs-only push reuses all six suites and completes in ~2 seconds with zero PowerPoint launches.
+  - `-Force` re-runs everything, for when a result is suspected flaky or environment-dependent rather than stale. `-ListInputs` prints each suite's derived paths and fingerprint and exits without running anything, so the dependency mapping can be audited without paying for a run.
+
 ### Security
 
 - **Scriban bumped 6.6.0 → 7.2.6**: resolves NU1904 (critical) and four NU1902 (moderate) NuGet audit advisories that broke `dotnet restore` and caused the scheduled CodeQL workflow to fail on `main` since July

--- a/scripts/Invoke-LocalIntegrationGate.ps1
+++ b/scripts/Invoke-LocalIntegrationGate.ps1
@@ -47,7 +47,15 @@ param(
     # Run only the named suites, for iterating on the gate itself. A partial run cannot
     # be evidence for a commit, so this forces binding=none no matter how clean the tree
     # is - otherwise the gate could mint a passing manifest for coverage it never ran.
-    [string[]]$Only = @()
+    [string[]]$Only = @(),
+
+    # Re-run every suite even when its inputs are unchanged. Use when you suspect a
+    # flaky or environment-dependent result rather than a code change.
+    [switch]$Force,
+
+    # Print each suite's derived input paths and content hash, then exit. Runs nothing,
+    # launches nothing - for checking that the dependency derivation is sane.
+    [switch]$ListInputs
 )
 
 $ErrorActionPreference = 'Stop'
@@ -71,7 +79,7 @@ $dirty = @(git status --porcelain -- src tests | Where-Object { $_ -ne '' })
 $binding = 'commit'
 
 if ($dirty.Count -gt 0) {
-    if (-not $AllowDirty) {
+    if (-not $AllowDirty -and -not $ListInputs) {
         Write-Host "REFUSED: uncommitted changes under src/ or tests/." -ForegroundColor Red
         Write-Host ""
         Write-Host "Evidence is bound to a commit. Running now would test content that no"
@@ -118,6 +126,82 @@ $dotnetVersion = (dotnet --version).Trim()
 Write-Host "PowerPoint: $powerPointVersion   .NET SDK: $dotnetVersion   Machine: $env:COMPUTERNAME"
 Write-Host ""
 
+# ---------------------------------------------------------------- suite input hashing
+# Every ComInterop test creates and tears down a real PowerPoint process, because session
+# lifecycle is the thing under test. That is ~95 launches, and re-running them to re-prove
+# a result about code that did not change is the single most disruptive thing this gate
+# does to the machine it runs on.
+#
+# So a suite is re-run only when its inputs changed. "Inputs" is derived, not declared:
+# the transitive ProjectReference closure of the test project, which is exactly the code
+# that suite can exercise. A change confined to src/PptMcp.Core cannot alter the behaviour
+# of a suite that never references it.
+#
+# The hash is built from git blob SHAs, so it describes committed content precisely. That
+# is only meaningful on a clean tree, so reuse is disabled outright unless binding=commit.
+function Get-ProjectClosure {
+    param([string]$ProjectPath)
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    $frontier = @([System.IO.Path]::GetFullPath($ProjectPath))
+
+    while ($frontier.Count -gt 0) {
+        $next = @()
+        foreach ($proj in $frontier) {
+            if (-not $seen.Add($proj)) { continue }
+            if (-not (Test-Path $proj)) { continue }
+
+            $dir = Split-Path -Parent $proj
+            try { [xml]$xml = Get-Content $proj -Raw } catch { continue }
+
+            foreach ($group in $xml.Project.ItemGroup) {
+                foreach ($ref in $group.ProjectReference) {
+                    if ($ref -and $ref.Include) {
+                        $next += [System.IO.Path]::GetFullPath((Join-Path $dir $ref.Include))
+                    }
+                }
+            }
+        }
+        $frontier = $next
+    }
+
+    return @($seen)
+}
+
+function Get-SuiteInputsHash {
+    param([string[]]$Paths)
+
+    # git ls-files -s prints mode, blob SHA, stage and path for every tracked file. The
+    # blob SHA is the content, so this is a precise content fingerprint of the inputs
+    # without reading a single file ourselves.
+    $listing = git ls-files -s -- @Paths 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $listing) { return $null }
+
+    $joined = ($listing | Sort-Object) -join "`n"
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($joined)
+    $sha = [System.Security.Cryptography.SHA256]::HashData($bytes)
+    return [System.Convert]::ToHexString($sha).ToLowerInvariant()
+}
+
+function Get-SuiteInputPaths {
+    param([hashtable]$Suite)
+
+    $paths = @()
+
+    if ($Suite.Project) {
+        foreach ($proj in Get-ProjectClosure (Join-Path $repoRoot $Suite.Project)) {
+            $dir = Split-Path -Parent $proj
+            $paths += [System.IO.Path]::GetRelativePath($repoRoot, $dir).Replace('\', '/')
+        }
+    }
+
+    foreach ($extra in @($Suite.ExtraInputs)) {
+        if ($extra) { $paths += $extra }
+    }
+
+    return @($paths | Sort-Object -Unique)
+}
+
 # ---------------------------------------------------------------- build
 if (-not $NoBuild) {
     Write-Host "Building solution (Release)..." -ForegroundColor Cyan
@@ -145,10 +229,14 @@ $guard = Join-Path $PSScriptRoot 'Invoke-GuardedTest.ps1'
 
 $suites = @(
     @{
-        Name    = 'cli-smoke-workflow'
-        Kind    = 'script'
-        Script  = (Join-Path $PSScriptRoot 'Test-CliWorkflow.ps1')
-        Args    = @()
+        Name        = 'cli-smoke-workflow'
+        Kind        = 'script'
+        Script      = (Join-Path $PSScriptRoot 'Test-CliWorkflow.ps1')
+        Args        = @()
+        # Not a test project, but it drives the built CLI, so it depends on the CLI's
+        # project closure plus the workflow script itself.
+        Project     = 'src/PptMcp.CLI/PptMcp.CLI.csproj'
+        ExtraInputs = @('scripts/Test-CliWorkflow.ps1')
     }
     @{
         Name    = 'mcp-smoke'
@@ -190,6 +278,18 @@ $suites = @(
 $results = @()
 $gateFailed = $false
 
+if ($ListInputs) {
+    foreach ($suite in $suites) {
+        $paths = Get-SuiteInputPaths $suite
+        $hash = Get-SuiteInputsHash $paths
+        Write-Host "[$($suite.Name)]" -ForegroundColor Cyan
+        Write-Host "  hash: $hash"
+        foreach ($p in $paths) { Write-Host "  - $p" }
+        Write-Host ""
+    }
+    exit 0
+}
+
 if ($Only.Count -gt 0) {
     $unknown = @($Only | Where-Object { $_ -notin ($suites | ForEach-Object { $_.Name }) })
     if ($unknown.Count -gt 0) {
@@ -204,11 +304,61 @@ if ($Only.Count -gt 0) {
     Write-Host ""
 }
 
+# ---------------------------------------------------------------- prior evidence
+# Load the manifest this run is about to replace, so suites whose inputs are unchanged can
+# stand on their previous result instead of launching PowerPoint again to reach it.
+$previousSuites = @{}
+$previousCommit = $null
+
+if (-not $Force -and $binding -eq 'commit' -and (Test-Path $OutputPath)) {
+    try {
+        $prev = Get-Content $OutputPath -Raw | ConvertFrom-Json
+        if ($prev.schemaVersion -eq 1 -and $prev.binding -eq 'commit') {
+            $previousCommit = $prev.commit
+            foreach ($s in @($prev.suites)) {
+                if ($s.result -eq 'pass' -and $s.inputsHash) {
+                    $previousSuites[$s.name] = $s
+                }
+            }
+        }
+    }
+    catch {
+        # An unreadable manifest simply means no reuse. It is never a reason to fail.
+        $previousSuites = @{}
+    }
+}
+
 foreach ($suite in $suites) {
     Write-Host "[$($suite.Name)]" -ForegroundColor Cyan
     $suiteStart = Get-Date
     $testCount = $null
     $output = ''
+
+    # ------------------------------------------------------------ reuse check
+    $inputsHash = if ($binding -eq 'commit') { Get-SuiteInputsHash (Get-SuiteInputPaths $suite) } else { $null }
+
+    if ($inputsHash -and $previousSuites.ContainsKey($suite.Name)) {
+        $prior = $previousSuites[$suite.Name]
+        if ($prior.inputsHash -eq $inputsHash) {
+            $priorFrom = if ($prior.reusedFrom) { $prior.reusedFrom } else { $previousCommit }
+
+            Write-Host "  REUSED - $($prior.tests) test(s), inputs unchanged since $($priorFrom.Substring(0, 8))" -ForegroundColor DarkGray
+            Write-Host ""
+
+            $results += [pscustomobject]@{
+                name            = $suite.Name
+                kind            = $suite.Kind
+                tests           = [int]$prior.tests
+                result          = 'pass'
+                exitCode        = 0
+                durationSeconds = [double]$prior.durationSeconds
+                inputsHash      = $inputsHash
+                reused          = $true
+                reusedFrom      = $priorFrom
+            }
+            continue
+        }
+    }
 
     if ($suite.Kind -eq 'script') {
         # *>&1 and not 2>&1: these scripts report through Write-Host, which writes to the
@@ -256,6 +406,8 @@ foreach ($suite in $suites) {
         result          = if ($passed) { 'pass' } else { 'fail' }
         exitCode        = $exitCode
         durationSeconds = $suiteDuration
+        inputsHash      = $inputsHash
+        reused          = $false
     }
 
     if ($passed) {
@@ -325,7 +477,9 @@ if ($outDir -and -not (Test-Path $outDir)) {
 $manifest | ConvertTo-Json -Depth 6 | Out-File -FilePath $OutputPath -Encoding utf8
 
 Write-Host "=================================="
-Write-Host "Suites: $($results.Count)   Tests: $totalTests   Duration: $([math]::Round($totalDuration / 60, 1))m"
+$reusedCount = @($results | Where-Object { $_.reused }).Count
+$ranCount = $results.Count - $reusedCount
+Write-Host "Suites: $($results.Count) ($ranCount run, $reusedCount reused)   Tests: $totalTests   Duration: $([math]::Round($totalDuration / 60, 1))m"
 Write-Host "Manifest: $OutputPath"
 Write-Host ""
 

--- a/scripts/check-integration-evidence.ps1
+++ b/scripts/check-integration-evidence.ps1
@@ -169,7 +169,8 @@ Write-Host "  machine: $($manifest.machine.name), PowerPoint $($manifest.machine
 
 if ($Detailed) {
     foreach ($s in $suites) {
-        Write-Host "  - $($s.name): $($s.tests) test(s), $($s.durationSeconds)s"
+        $tag = if ($s.reused) { "  (reused from $($s.reusedFrom.Substring(0, 8)) - inputs unchanged)" } else { '' }
+        Write-Host "  - $($s.name): $($s.tests) test(s), $($s.durationSeconds)s$tag"
     }
 }
 


### PR DESCRIPTION
## Problem

A full gate run takes **~11 minutes and launches PowerPoint roughly 200 times**, and it ran in full for *every* push — including a push that changed only documentation, or one that touched a single project most suites do not depend on.

That cost is not sustainable for a hook that blocks pushing. A gate this expensive on every push is a gate that ends up disabled, which would quietly undo #143.

## Approach

Re-run a suite only when its own inputs changed.

**Inputs are derived, not declared.** Each suite's input set comes from its **transitive `ProjectReference` closure**, walked from the suite's project file. A hand-maintained path list would silently drift from the build graph and start reusing evidence that no longer applies.

**Fingerprint via git's own hashes.** `git ls-files -s` prints the blob SHA for every tracked file under those paths. That *is* the content hash, so the fingerprint is exact without re-reading a single file.

**Reuse stays honest.** A carried-forward suite is marked `reused` and records `reusedFrom` — the commit it was actually verified on. Evidence therefore still names the run that produced it, rather than implying it ran now.

**Reuse is refused unless both manifests are `binding=commit`.** `git ls-files` reports the *index*, so on a dirty tree its blob SHAs would describe content no commit holds. This is the same reason the gate already refuses to mint evidence from a dirty tree.

## Measured effect

| Scenario | Before | After |
|---|---|---|
| Docs-only push | ~11 min, ~200 PowerPoint launches | **1.9s, 0 launches**, 790 tests attested |
| `src/PptMcp.Core` change | all 6 suites | `cominterop-full` reused — **96 tests / ~96 launches skipped**; all Core-dependent suites still run |

Selectivity was verified by staging a real edit to `src/PptMcp.Core/Commands/Slide/SlideCommands.cs` and diffing the fingerprints:

```
cli-integration        INVALIDATED (will run)
cli-smoke-workflow     INVALIDATED (will run)
cominterop-full        unchanged (reusable)
core-integration       INVALIDATED (will run)
mcp-integration        INVALIDATED (will run)
mcp-smoke              INVALIDATED (will run)
```

## What I got wrong on the way

Worth recording, because both were caught by probing rather than by reading the code:

1. **A hashtable where the code expected an object.** Reused suites were emitted as `[ordered]@{}`, so `Measure-Object -Property tests` read nothing from them — a fully-reused run reported `Tests: 0` and **failed the gate**. Had I trusted the first "it reuses correctly!" output, I would have shipped a gate that fails whenever it saves the most time.
2. **`-ListInputs` was unreachable on a dirty tree**, because the dirty-tree refusal came first. A diagnostic that refuses to answer precisely when you are mid-change is not a diagnostic. It now runs regardless of tree state, since it executes nothing.

## Also in this PR

- `-Force` re-runs everything, for a result suspected **flaky** rather than stale — the two failure modes reuse cannot distinguish.
- `-ListInputs` prints each suite's derived paths and fingerprint and exits, so the dependency mapping can be audited without paying for a run.
- `check-integration-evidence.ps1 -Detailed` tags reused suites.
- `AGENTS.md` and `.github/copilot-instructions.md` document the behaviour, including a warning not to route around the gate.

## Verification

- Reuse path: 6/6 suites reused, **790 tests attested, GATE PASSED, 1.9s, 0 PowerPoint launches**.
- Fresh path: exercised (`cli-smoke-workflow` 11 tests, `mcp-smoke` 2 tests) with the new `inputsHash` / `reused` fields recorded.
- Selectivity: proven by staged-edit fingerprint diff, above.
- Both scripts confirmed **0 non-ASCII bytes** (cp1252 parse hazard).
- Full pre-commit suite green.

No `src/` or `tests/` changes, so this PR requires no integration evidence of its own.

Follow-up to #143.
