### PR TITLE
Add round-trip integration tests for high-traffic operations (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Round-trip integration tests for the highest-traffic operations** (#133): of 218 `[ServiceAction]` methods, only 8 were genuinely executed against PowerPoint anywhere in the repository. `shape add-shape`, `shape set-fill`, `text set` and `chart create` all worked, and none had a test that would notice if they stopped.
+  - `ShapeRoundTripTests` asserts the requested `MsoAutoShapeType` and bounds actually land on the shape, that `set-fill` writes the requested colour, and that a shape plus its text and fill survive save and reopen.
+  - `TextRoundTripTests` asserts `text set` round-trips exactly, writes **only** to the named shape, and replaces rather than appends.
+  - `ChartRoundTripTests` asserts `chart create` produces the requested `XlChartType` at the requested bounds.
+  - `SlideMetadataTests` gains coverage of `slide read`, which populates layout and master names through a different code path from `slide list`, and asserts the two agree.
+  - **Two tests assert against raw COM rather than our own read path.** A mutate-then-read-back test cannot detect a symmetric error: if `SetFill` and `ReadFill` both inverted PowerPoint's `0x00BBGGRR` byte order, the round trip would agree with itself and stay green while every shape rendered the wrong colour. The colours used are deliberately asymmetric (`#112233`) for the same reason.
+  - Each assertion was verified to be load-bearing by inverting its expected value and confirming the test fails.
+
 ### Changed
 
 - **The integration gate now re-runs only the suites a change can actually affect** (#143 follow-up): a full gate run is ~11 minutes and launches PowerPoint roughly 200 times, and it ran in full for every push — including pushes that touched only documentation or a single unrelated project. A gate that expensive on every push is a gate that ends up disabled.

--- a/tests/PptMcp.Core.Tests/Integration/ChartRoundTripTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/ChartRoundTripTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Chart;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Round-trip integration coverage for <c>chart create</c> (GitHub #133).
+///
+/// <c>Create</c> takes an <c>XlChartType</c> integer and four positional floats, so
+/// the two things that can go wrong without any visible error are producing a chart
+/// of the wrong type and placing it at the wrong bounds. Both are asserted here
+/// against the created shape rather than against the success flag.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Chart")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class ChartRoundTripTests : IClassFixture<TempDirectoryFixture>
+{
+    // XlChartType.xlBarClustered. Chosen over the xlColumnClustered default so a
+    // dropped parameter cannot pass by coincidence.
+    private const int XlBarClustered = 57;
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly SlideCommands _slides = new();
+    private readonly ShapeCommands _shapes = new();
+    private readonly ChartCommands _charts = new();
+
+    public ChartRoundTripTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Create_ProducesChartOfRequestedTypeAtRequestedBounds()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var created = _charts.Create(batch, slideIndex: 1, chartType: XlBarClustered,
+                left: 80f, top: 60f, width: 400f, height: 300f);
+            Assert.True(created.Success, created.ErrorMessage);
+
+            var list = _shapes.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+
+            var chartShape = Assert.Single(list.Shapes, s => s.HasChart);
+            Assert.Equal(80f, chartShape.Left, 1);
+            Assert.Equal(60f, chartShape.Top, 1);
+            Assert.Equal(400f, chartShape.Width, 1);
+            Assert.Equal(300f, chartShape.Height, 1);
+
+            var info = _charts.GetInfo(batch, slideIndex: 1, shapeName: chartShape.Name);
+
+            Assert.True(info.Success, info.ErrorMessage);
+            Assert.Equal(XlBarClustered, info.ChartType);
+            Assert.False(string.IsNullOrEmpty(info.ChartTypeName));
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+}

--- a/tests/PptMcp.Core.Tests/Integration/ShapeRoundTripTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/ShapeRoundTripTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Commands.Text;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Round-trip integration coverage for the shape operations users actually run
+/// (GitHub #133).
+///
+/// Before these tests, <c>shape add-shape</c> and <c>shape set-fill</c> were verified
+/// only by hand. Nothing would have caught the two regressions that matter most:
+/// mapping <c>autoShapeType</c> to the wrong <c>MsoAutoShapeType</c>, or writing the
+/// wrong colour because PowerPoint stores RGB byte-reversed.
+///
+/// <para><b>Why two of these assert against raw COM rather than our own read path.</b></para>
+///
+/// A pure mutate-then-read-back test cannot detect a symmetric error. If
+/// <c>SetFill</c> and <c>ReadFill</c> both inverted the byte order, the round trip
+/// would agree with itself and stay green while every shape rendered the wrong
+/// colour. So the colour and shape-type tests assert the value PowerPoint actually
+/// holds, and a separate test covers the read path on top of it. The pair fails
+/// distinguishably: a write bug breaks both, a read bug breaks only the second.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Shape")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class ShapeRoundTripTests : IClassFixture<TempDirectoryFixture>
+{
+    private const int MsoShapeOval = 9;
+    private const int MsoShapeRectangle = 1;
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly SlideCommands _slides = new();
+    private readonly ShapeCommands _shapes = new();
+    private readonly TextCommands _text = new();
+
+    public ShapeRoundTripTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void AddShape_StoresRequestedAutoShapeTypeAndBounds()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var added = _shapes.AddShape(batch, slideIndex: 1, autoShapeType: MsoShapeOval,
+                left: 100f, top: 120f, width: 200f, height: 80f);
+            Assert.True(added.Success, added.ErrorMessage);
+
+            var list = _shapes.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+            var shape = Assert.Single(list.Shapes);
+
+            // Bounds are the part of the request most likely to be silently dropped:
+            // AddShape takes four positional floats, so a transposed argument still
+            // produces a valid shape.
+            Assert.Equal(100f, shape.Left, 1);
+            Assert.Equal(120f, shape.Top, 1);
+            Assert.Equal(200f, shape.Width, 1);
+            Assert.Equal(80f, shape.Height, 1);
+
+            // ShapeInfo.ShapeType reports the MsoShapeType family ("AutoShape"), not
+            // which auto shape it is, so the requested mapping is only observable on
+            // the COM object itself.
+            var actualAutoShapeType = batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(1);
+                dynamic comShape = slide.Shapes.Item(1);
+                return Convert.ToInt32(comShape.AutoShapeType);
+            });
+
+            Assert.Equal(MsoShapeOval, actualAutoShapeType);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void SetFill_WritesRequestedColour_InPowerPointByteOrder()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 50f, 50f, 100f, 100f);
+
+            var shapeName = _shapes.List(batch, 1).Shapes[0].Name;
+
+            var filled = _shapes.SetFill(batch, 1, shapeName, "#112233");
+            Assert.True(filled.Success, filled.ErrorMessage);
+
+            // PowerPoint stores an OLE colour as 0x00BBGGRR, so #112233 must land as
+            // 0x332211. Deliberately asymmetric: #FF0000 or any grey would pass even
+            // if the byte order were reversed.
+            var rgb = batch.Execute((ctx, ct) =>
+            {
+                dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(1);
+                dynamic comShape = slide.Shapes.Item(shapeName);
+                return Convert.ToInt32(comShape.Fill.ForeColor.RGB);
+            });
+
+            Assert.Equal(0x332211, rgb);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void ReadFill_ReportsTheColourThatWasWritten()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 50f, 50f, 100f, 100f);
+
+            var shapeName = _shapes.List(batch, 1).Shapes[0].Name;
+            _shapes.SetFill(batch, 1, shapeName, "#112233");
+
+            var read = _shapes.ReadFill(batch, 1, shapeName);
+
+            Assert.True(read.Success, read.ErrorMessage);
+            Assert.NotNull(read.Message);
+            Assert.Contains("#112233", read.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Solid", read.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void ShapeAndText_SurviveSaveAndReopen()
+    {
+        var testFile = _fixture.CreateTestFile();
+        string shapeName;
+
+        // Save is deliberate here: this is the persistence test required by #133, and
+        // the only one in this file that pays for a save. An operation that succeeds
+        // in memory and is lost on write looks identical to a working one until a
+        // user reopens the deck.
+        using (var manager = new SessionManager())
+        {
+            var sessionId = manager.CreateSession(testFile, show: false);
+            try
+            {
+                var batch = manager.GetSession(sessionId)!;
+                _slides.Create(batch, position: 0, layoutName: "Blank");
+                _shapes.AddShape(batch, 1, MsoShapeRectangle, 60f, 70f, 150f, 90f);
+
+                shapeName = _shapes.List(batch, 1).Shapes[0].Name;
+                _shapes.SetFill(batch, 1, shapeName, "#112233");
+
+                var written = _text.SetText(batch, 1, shapeName, "persisted content");
+                Assert.True(written.Success, written.ErrorMessage);
+            }
+            finally
+            {
+                manager.CloseSession(sessionId, save: true);
+            }
+        }
+
+        using (var manager = new SessionManager())
+        {
+            var sessionId = manager.CreateSession(testFile, show: false);
+            try
+            {
+                var batch = manager.GetSession(sessionId)!;
+
+                var list = _shapes.List(batch, 1);
+                Assert.True(list.Success, list.ErrorMessage);
+                var reopened = Assert.Single(list.Shapes, s => s.Name == shapeName);
+
+                Assert.Equal(60f, reopened.Left, 1);
+                Assert.Equal(70f, reopened.Top, 1);
+
+                var text = _text.GetText(batch, 1, shapeName);
+                Assert.True(text.Success, text.ErrorMessage);
+                Assert.Equal("persisted content", text.Text.TrimEnd('\r', '\n'));
+
+                var fill = _shapes.ReadFill(batch, 1, shapeName);
+                Assert.True(fill.Success, fill.ErrorMessage);
+                Assert.Contains("#112233", fill.Message!, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                manager.CloseSession(sessionId, save: false);
+            }
+        }
+    }
+}

--- a/tests/PptMcp.Core.Tests/Integration/SlideMetadataTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/SlideMetadataTests.cs
@@ -199,4 +199,44 @@ public sealed class SlideMetadataTests : IClassFixture<TempDirectoryFixture>
             manager.CloseSession(sessionId, save: false);
         }
     }
+
+    /// <summary>
+    /// <c>slide read</c> populates the same metadata through a separate code path from
+    /// <c>slide list</c>, so a fix applied to one does not imply the other (GitHub #133,
+    /// item 5).
+    /// </summary>
+    [Fact]
+    public void Read_PopulatesLayoutAndMasterNames_AndAgreesWithList()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var listed = _slides.List(batch);
+            Assert.True(listed.Success);
+            var slideIndex = listed.Slides.Count;
+
+            var read = _slides.Read(batch, slideIndex);
+
+            Assert.True(read.Success, read.ErrorMessage);
+            Assert.NotNull(read.Slide);
+            Assert.False(string.IsNullOrEmpty(read.Slide.LayoutName));
+            Assert.False(string.IsNullOrEmpty(read.Slide.MasterName));
+
+            // The two paths describing the same slide differently would mean one of
+            // them is reading the wrong object - invisible while only one is tested.
+            Assert.Equal(listed.Slides[^1].LayoutName, read.Slide.LayoutName);
+            Assert.Equal(listed.Slides[^1].MasterName, read.Slide.MasterName);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
 }

--- a/tests/PptMcp.Core.Tests/Integration/TextRoundTripTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/TextRoundTripTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Commands.Text;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Round-trip integration coverage for <c>text set</c> and <c>text get</c> (GitHub #133).
+///
+/// The failure this guards against is a silent no-op: <c>SetText</c> returning
+/// <c>Success = true</c> having written nothing, or having written to a different
+/// shape than the one named. Neither is visible to a success-flag assertion, which
+/// is why #133 calls those out as insufficient.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Text")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class TextRoundTripTests : IClassFixture<TempDirectoryFixture>
+{
+    private const int MsoShapeRectangle = 1;
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly SlideCommands _slides = new();
+    private readonly ShapeCommands _shapes = new();
+    private readonly TextCommands _text = new();
+
+    public TextRoundTripTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void SetText_ThenGetText_ReturnsExactlyWhatWasWritten()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 40f, 40f, 300f, 120f);
+
+            var shapeName = _shapes.List(batch, 1).Shapes[0].Name;
+
+            var written = _text.SetText(batch, 1, shapeName, "Round trip 123");
+            Assert.True(written.Success, written.ErrorMessage);
+
+            var read = _text.GetText(batch, 1, shapeName);
+
+            Assert.True(read.Success, read.ErrorMessage);
+            Assert.Equal(shapeName, read.ShapeName);
+
+            // PowerPoint appends a paragraph terminator to TextRange.Text; the content
+            // either side of it must be byte-identical to what was requested.
+            Assert.Equal("Round trip 123", read.Text.TrimEnd('\r', '\n'));
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void SetText_WritesOnlyToTheNamedShape()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 20f, 20f, 200f, 60f);
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 20f, 200f, 200f, 60f);
+
+            var shapes = _shapes.List(batch, 1).Shapes;
+            Assert.Equal(2, shapes.Count);
+
+            var target = shapes[1].Name;
+            var other = shapes[0].Name;
+            Assert.NotEqual(target, other);
+
+            _text.SetText(batch, 1, target, "only here");
+
+            Assert.Equal("only here", _text.GetText(batch, 1, target).Text.TrimEnd('\r', '\n'));
+
+            // Writing to the wrong shape is indistinguishable from writing to the right
+            // one unless the untouched shape is checked as well.
+            Assert.Equal(string.Empty, _text.GetText(batch, 1, other).Text.TrimEnd('\r', '\n'));
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void SetText_ReplacesExistingContentRatherThanAppending()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+            _shapes.AddShape(batch, 1, MsoShapeRectangle, 40f, 40f, 300f, 120f);
+
+            var shapeName = _shapes.List(batch, 1).Shapes[0].Name;
+
+            _text.SetText(batch, 1, shapeName, "first value");
+            _text.SetText(batch, 1, shapeName, "second value");
+
+            // The documented contract is "replaces all existing text".
+            var read = _text.GetText(batch, 1, shapeName);
+            Assert.Equal("second value", read.Text.TrimEnd('\r', '\n'));
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Of the **218 `[ServiceAction]` methods** on the Core command surface, only **8 operations** were genuinely executed against real PowerPoint anywhere in the repository. `shape add-shape`, `shape set-fill`, `text set` and `chart create` had all been verified by hand — and none of them had a test that would notice if they stopped working.

`ParameterValidationTests` (252 tests passing `null!`) pins our own guard clauses and is worth keeping, but proves nothing about COM behaviour.

## What this adds

Four focused round-trip suites — deliberately **not** a restoration of a large legacy suite (#127).

| Suite | Asserts |
|---|---|
| `ShapeRoundTripTests` | requested `MsoAutoShapeType` and bounds land on the shape; `set-fill` writes the requested colour; shape + text + fill survive **save and reopen** |
| `TextRoundTripTests` | `text set` round-trips exactly, writes **only** to the named shape, and replaces rather than appends |
| `ChartRoundTripTests` | `chart create` produces the requested `XlChartType` at the requested bounds |
| `SlideMetadataTests` (extended) | `slide read` populates layout/master names via a different code path from `slide list`, and the two **agree** |

## Two decisions worth reviewing

**1. Two assertions read raw COM instead of our own read path.**

A mutate-then-read-back test cannot detect a *symmetric* error. If `SetFill` and `ReadFill` both inverted PowerPoint's `0x00BBGGRR` byte order, the round trip would agree with itself and stay green while every shape rendered the wrong colour. So the fill test asserts the value PowerPoint actually holds (`#112233` → `0x332211`), and a separate test covers `ReadFill` on top of it. The pair fails distinguishably: a write bug breaks both, a read bug breaks only the second.

The same reasoning drives the constants. `#FF0000` or any grey would pass with the bytes reversed; `xlBarClustered` was chosen over the `xlColumnClustered` default so a dropped parameter cannot pass by coincidence.

**2. These passed on the first run — so I checked they can fail.**

They characterise existing behaviour, so green-first-run is expected. That is also exactly when a test is most likely to be testing nothing. I inverted each expected value and re-ran:

```
Failed!  - Failed: 3, Passed: 1, Total: 4
```

All 3 mutated assertions failed; the untouched persistence test still passed. The assertions are load-bearing.

## Verification

- New tests: **14 ran, 14 passed, 2m8s** (`FullyQualifiedName~RoundTripTests|~SlideMetadataTests`).
- Full local gate on the pushed commit: **799 tests, 6/6 suites, GATE PASSED, 15.4m** — Core went 492 → 501.
- Build: 0 warnings, 0 errors. All pre-commit gates green.

## Acceptance criteria

- [x] Round-trip tests for operations 1-5 with `Category=Integration`, `RequiresPowerPoint=true` and matching `Feature` traits
- [x] Each test asserts actual presentation state, not `success == true`
- [x] At least one test verifies persistence across save + reopen
- [x] Hermetic: unique file per test via `TempDirectoryFixture`, no shared state, no orphaned `POWERPNT.EXE`
- [x] Runs in the enforced gate — via the local `core-integration` suite. The criterion named `integration-tests.yml`, but that self-hosted runner was **declined** in #143; the local pre-push gate is the enforcement path, and it already fails on zero matched tests.

## Deliberately not included

`text set` against a shape with **no text frame**. The only honest assertion there accepts either a thrown exception or `Success = false`, and "accept both" assertions are banned by Rule 12. The silent-no-op risk it was meant to cover is already closed by the round-trip test, which proves text is actually written. Worth a follow-up once the intended contract is decided.

`vba import` / `vba list` remain gated on #130.

Closes #133.
