### PR TITLE
Release the collection proxies ShapeCommands was abandoning (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ShapeCommands` no longer abandons a COM proxy on every shape and slide lookup** (#137, #126): 68 call sites wrote `slide.Shapes.Item(name)` or `((dynamic)ctx.Presentation).Slides.Item(i)` inline. Each one materialised a `Shapes` or `Slides` collection RCW that was never bound to a local, so `ComUtilities.Release` could not be called on it **even in principle** — the try/finally pattern Rule 22 mandates cannot express a release for an object you never named.
+  - This is not only hygiene. #148 established by measurement that a single leaked collection proxy is enough to stop the STA thread exiting, turning session teardown into a 45-second timeout (leaky 45093ms vs clean 5501ms).
+  - Adds `ComUtilities.GetSlide`, `GetShape` and `GetShapeAt`, which bind the intermediate collection to a local and release it in a `finally`. They live in `ComInterop` rather than in a command class because every remaining offender — `TextCommands`, `SlideTableCommands`, `ChartCommands` — needs exactly the same accessor.
+  - `ShapeCommands.cs` drops from **52 inline chains to 19**; the repository ratchet drops from 173 to 140.
+
 ### Added
 
 - **Round-trip integration tests for the highest-traffic operations** (#133): of 218 `[ServiceAction]` methods, only 8 were genuinely executed against PowerPoint anywhere in the repository. `shape add-shape`, `shape set-fill`, `text set` and `chart create` all worked, and none had a test that would notice if they stopped.

--- a/scripts/dynamic-casts-baseline.txt
+++ b/scripts/dynamic-casts-baseline.txt
@@ -1,4 +1,4 @@
-﻿src\PptMcp.Core\Commands\Accessibility\AccessibilityCommands.cs=2
+src\PptMcp.Core\Commands\Accessibility\AccessibilityCommands.cs=2
 src\PptMcp.Core\Commands\Animation\AnimationCommands.cs=6
 src\PptMcp.Core\Commands\Background\BackgroundCommands.cs=5
 src\PptMcp.Core\Commands\Chart\ChartCommands.cs=10
@@ -11,7 +11,7 @@ src\PptMcp.Core\Commands\Media\MediaCommands.cs=4
 src\PptMcp.Core\Commands\Notes\NotesCommands.cs=3
 src\PptMcp.Core\Commands\Placeholder\PlaceholderCommands.cs=3
 src\PptMcp.Core\Commands\Proofing\ProofingCommands.cs=1
-src\PptMcp.Core\Commands\Shape\ShapeCommands.cs=35
+src\PptMcp.Core\Commands\Shape\ShapeCommands.cs=1
 src\PptMcp.Core\Commands\ShapeAlign\ShapeAlignCommands.cs=2
 src\PptMcp.Core\Commands\Slide\SlideCommands.cs=6
 src\PptMcp.Core\Commands\SlideTable\SlideTableCommands.cs=13

--- a/scripts/inline-com-chains-baseline.txt
+++ b/scripts/inline-com-chains-baseline.txt
@@ -1,6 +1,6 @@
 # Inline COM member chains per file. See check-inline-com-chains.ps1.
 # Counts may only go down. Regenerate with -UpdateBaseline.
-# Total at last update: 173
+# Total at last update: 140
 src\PptMcp.Core\Commands\Accessibility\AccessibilityCommands.cs=1
 src\PptMcp.Core\Commands\Animation\AnimationCommands.cs=1
 src\PptMcp.Core\Commands\Background\BackgroundCommands.cs=8
@@ -16,7 +16,7 @@ src\PptMcp.Core\Commands\Media\MediaCommands.cs=4
 src\PptMcp.Core\Commands\Notes\NotesCommands.cs=5
 src\PptMcp.Core\Commands\Placeholder\PlaceholderCommands.cs=4
 src\PptMcp.Core\Commands\Proofing\ProofingCommands.cs=4
-src\PptMcp.Core\Commands\Shape\ShapeCommands.cs=52
+src\PptMcp.Core\Commands\Shape\ShapeCommands.cs=19
 src\PptMcp.Core\Commands\Slide\ShapeHelpers.cs=2
 src\PptMcp.Core\Commands\Slide\SlideCommands.cs=4
 src\PptMcp.Core\Commands\Slideshow\SlideshowCommands.cs=2

--- a/src/PptMcp.ComInterop/ComUtilities.cs
+++ b/src/PptMcp.ComInterop/ComUtilities.cs
@@ -73,6 +73,79 @@ public static class ComUtilities
     }
 
     /// <summary>
+    /// Gets a slide from a presentation without abandoning the intermediate
+    /// <c>Slides</c> collection.
+    ///
+    /// <para>
+    /// Writing <c>presentation.Slides.Item(i)</c> inline materialises a <c>Slides</c>
+    /// RCW that is never bound to a local, so <see cref="Release{T}"/> cannot be called
+    /// on it even in principle. The proxy survives until a garbage collection that may
+    /// never come while the STA thread is alive, which is the leak class tracked by
+    /// GitHub #137 - and, per #148, a leaked collection proxy is enough to stop the STA
+    /// thread exiting and turn session teardown into a 45-second timeout.
+    /// </para>
+    /// </summary>
+    /// <param name="presentation">Presentation COM object.</param>
+    /// <param name="slideIndex">1-based slide index. PowerPoint collections are not zero-based.</param>
+    /// <returns>The slide COM object. The caller owns it and must release it.</returns>
+    public static dynamic GetSlide(dynamic presentation, int slideIndex)
+    {
+        dynamic? slides = null;
+        try
+        {
+            slides = presentation.Slides;
+            return slides.Item(slideIndex);
+        }
+        finally
+        {
+            ComUtilities.Release(ref slides!);
+        }
+    }
+
+    /// <summary>
+    /// Gets a shape from a slide by name without abandoning the intermediate
+    /// <c>Shapes</c> collection. See <see cref="GetSlide"/> for why the inline form
+    /// leaks.
+    /// </summary>
+    /// <param name="slide">Slide COM object.</param>
+    /// <param name="shapeName">Shape name.</param>
+    /// <returns>The shape COM object. The caller owns it and must release it.</returns>
+    public static dynamic GetShape(dynamic slide, string shapeName)
+    {
+        dynamic? shapes = null;
+        try
+        {
+            shapes = slide.Shapes;
+            return shapes.Item(shapeName);
+        }
+        finally
+        {
+            ComUtilities.Release(ref shapes!);
+        }
+    }
+
+    /// <summary>
+    /// Gets a shape from a slide by 1-based position. See <see cref="GetSlide"/> for
+    /// why the inline form leaks.
+    /// </summary>
+    /// <param name="slide">Slide COM object.</param>
+    /// <param name="shapeIndex">1-based shape index.</param>
+    /// <returns>The shape COM object. The caller owns it and must release it.</returns>
+    public static dynamic GetShapeAt(dynamic slide, int shapeIndex)
+    {
+        dynamic? shapes = null;
+        try
+        {
+            shapes = slide.Shapes;
+            return shapes.Item(shapeIndex);
+        }
+        finally
+        {
+            ComUtilities.Release(ref shapes!);
+        }
+    }
+
+    /// <summary>
     /// Safely gets a string property from a COM object, returning empty string if null
     /// </summary>
     /// <param name="obj">COM object</param>

--- a/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
+++ b/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
@@ -11,7 +11,7 @@ public class ShapeCommands : IShapeCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic shapes = slide.Shapes;
             try
             {
@@ -53,8 +53,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 return new ShapeDetailResult
@@ -76,7 +76,7 @@ public class ShapeCommands : IShapeCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             // msoTextOrientationHorizontal = 1
             dynamic shape = slide.Shapes.AddTextbox(1, left, top, width, height);
             try
@@ -103,7 +103,7 @@ public class ShapeCommands : IShapeCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic shape = slide.Shapes.AddShape(autoShapeType, left, top, width, height);
             try
             {
@@ -130,8 +130,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 if (left.HasValue) shape.Left = left.Value;
@@ -161,8 +161,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 shape.Delete();
@@ -188,8 +188,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 shape.ZOrder(zOrderCmd);
@@ -216,8 +216,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 if (colorHex.Equals("none", StringComparison.OrdinalIgnoreCase))
@@ -254,8 +254,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 if (colorHex.Equals("none", StringComparison.OrdinalIgnoreCase))
@@ -291,8 +291,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 shape.Rotation = degrees;
@@ -318,7 +318,7 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic? group = null;
             try
             {
@@ -327,7 +327,7 @@ public class ShapeCommands : IShapeCommands
                 dynamic? first = null;
                 try
                 {
-                    first = slide.Shapes.Item(names[0]);
+                    first = ComUtilities.GetShape(slide, names[0]);
                     first.Select(true); // Replace=true to start new selection
                 }
                 finally
@@ -339,7 +339,7 @@ public class ShapeCommands : IShapeCommands
                     dynamic? s = null;
                     try
                     {
-                        s = slide.Shapes.Item(names[i]);
+                        s = ComUtilities.GetShape(slide, names[i]);
                         s.Select(false); // Replace=false to add to selection
                     }
                     finally
@@ -387,8 +387,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 shape.Ungroup();
@@ -414,8 +414,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 shape.AlternativeText = altText;
@@ -442,12 +442,12 @@ public class ShapeCommands : IShapeCommands
         return batch.Execute((ctx, ct) =>
         {
             dynamic pres = ctx.Presentation;
-            dynamic srcSlide = pres.Slides.Item(slideIndex);
-            dynamic shape = srcSlide.Shapes.Item(shapeName);
+            dynamic srcSlide = ComUtilities.GetSlide(pres, slideIndex);
+            dynamic shape = ComUtilities.GetShape(srcSlide, shapeName);
             try
             {
                 shape.Copy();
-                dynamic targetSlide = pres.Slides.Item(targetSlideIndex);
+                dynamic targetSlide = ComUtilities.GetSlide(pres, targetSlideIndex);
                 dynamic pasted = targetSlide.Shapes.Paste();
                 string newName = "";
                 try { newName = pasted.Item(1).Name?.ToString() ?? ""; } catch { }
@@ -477,8 +477,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 dynamic shadow = shape.Shadow;
@@ -521,14 +521,14 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic? startShape = null;
             dynamic? endShape = null;
             dynamic? connector = null;
             try
             {
-                startShape = slide.Shapes.Item(startShapeName);
-                endShape = slide.Shapes.Item(endShapeName);
+                startShape = ComUtilities.GetShape(slide, startShapeName);
+                endShape = ComUtilities.GetShape(slide, endShapeName);
 
                 // AddConnector(Type, BeginX, BeginY, EndX, EndY)
                 // Type: 1=msoConnectorStraight, 2=msoConnectorElbow, 3=msoConnectorCurve
@@ -574,7 +574,7 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             try
             {
                 string[] names = shapeNames.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -632,8 +632,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? dup = null;
             try
             {
@@ -666,8 +666,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 // msoFlipHorizontal=0, msoFlipVertical=1
@@ -695,8 +695,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? textFrame = null;
             try
             {
@@ -731,8 +731,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? fill = null;
             try
             {
@@ -787,8 +787,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? line = null;
             try
             {
@@ -851,8 +851,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 // TwoColorGradient(style, variant) - variant 1 is default direction
@@ -883,8 +883,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 dynamic glow = shape.Glow;
@@ -928,8 +928,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 dynamic reflection = shape.Reflection;
@@ -969,8 +969,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 // COM uses Transparency (0=opaque, 1=transparent), which is the inverse of opacity
@@ -995,7 +995,7 @@ public class ShapeCommands : IShapeCommands
     {
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic shapes = slide.Shapes;
             try
             {
@@ -1046,9 +1046,9 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic sourceShape = slide.Shapes.Item(sourceShapeName);
-            dynamic targetShape = slide.Shapes.Item(targetShapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic sourceShape = ComUtilities.GetShape(slide, sourceShapeName);
+            dynamic targetShape = ComUtilities.GetShape(slide, targetShapeName);
             try
             {
                 sourceShape.PickUp();
@@ -1080,8 +1080,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? actionSettings = null;
             dynamic? actionSetting = null;
             try
@@ -1139,8 +1139,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 // 0 = msoScaleFromTopLeft, relative to current size
@@ -1169,8 +1169,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             try
             {
                 // msoTrue = -1, msoFalse = 0
@@ -1200,8 +1200,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? softEdge = null;
             try
             {
@@ -1235,8 +1235,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? shadow = null;
             try
             {
@@ -1285,7 +1285,7 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
             dynamic? shape = null;
             try
             {
@@ -1316,8 +1316,8 @@ public class ShapeCommands : IShapeCommands
 
         return batch.Execute((ctx, ct) =>
         {
-            dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
-            dynamic shape = slide.Shapes.Item(shapeName);
+            dynamic slide = ComUtilities.GetSlide(ctx.Presentation, slideIndex);
+            dynamic shape = ComUtilities.GetShape(slide, shapeName);
             dynamic? threeD = null;
             try
             {


### PR DESCRIPTION
## What this fixes

68 call sites in `ShapeCommands.cs` reached a slide or a shape through an inline chain:

```csharp
dynamic slide = ((dynamic)ctx.Presentation).Slides.Item(slideIndex);
dynamic shape = slide.Shapes.Item(shapeName);
```

Each of those materialises a `Slides` or `Shapes` collection RCW that is **never bound to a local**. `ComUtilities.Release` cannot be called on it even in principle — the try/finally pattern Rule 22 mandates has nothing to name. The `slide` and `shape` proxies were released correctly; the collection between them was abandoned every single time.

## Why this is a defect and not tidiness

#148 established this by measurement rather than by assertion. A single abandoned collection proxy keeps the STA thread from exiting, so session teardown runs out its join timeout instead of completing:

| | teardown |
|---|---|
| one leaked collection proxy | **45093 ms** |
| clean | **5501 ms** |

Every one of these 68 sites was a candidate for that 45-second stall. That is what turns #137 from hygiene debt into a performance defect with a number attached.

## Approach

Three accessors added to `ComUtilities` — `GetSlide`, `GetShape`, `GetShapeAt` — each binding the intermediate collection to a local and releasing it in a `finally`:

```csharp
public static dynamic GetShape(dynamic slide, string shapeName)
{
    dynamic? shapes = null;
    try { shapes = slide.Shapes; return shapes.Item(shapeName); }
    finally { if (shapes != null) ComUtilities.Release(ref shapes!); }
}
```

They live in `ComInterop` rather than in a command class deliberately. The remaining offenders — `TextCommands` (26), `SlideTableCommands` (19), `ChartCommands` (13) — need the identical accessor, so the follow-up PRs become substitutions rather than new code.

## One thing worth flagging

The `((dynamic)ctx.Presentation).Slides.Item(...)` form was **never flagged** by `check-inline-com-chains.ps1` — the cast parenthesis breaks its regex. It leaks identically to the form that is flagged. Both are fixed here.

The gate undercounts, in other words, and fixing only what the gate could see would have left half the defect in place while reporting a clean ratchet. Worth remembering for the follow-up files.

## Ratchets

| ratchet | before | after |
|---|---|---|
| inline COM chains (repo) | 173 | **140** |
| inline COM chains (`ShapeCommands.cs`) | 52 | **19** |
| undocumented `((dynamic))` casts | 140 | **106** |

The cast drop is a side effect — `ComUtilities.GetSlide(ctx.Presentation, i)` needs no cast where `((dynamic)ctx.Presentation).Slides` did.

## Verification

- Solution builds Release, 0 warnings / 0 errors.
- `check-com-leaks.ps1`: passes, 221 acquisitions tracked.
- `Feature=Shape`: 4/4 pass.
- **Local integration gate on `82faf47`: 799 tests, 6/6 suites, 14.6m, GATE PASSED.**

The `Feature=Shape` trait covers only 4 tests, which is thin for a 68-site change — so the full gate, not the targeted filter, is the real evidence here. The `ShapeRoundTripTests` added in #133 are the specific net protecting this refactor: they mutate shape type and fill, save, reopen and read back, so a broken accessor could not pass them.
