### PR TITLE
Add one-click MCP install badges and fix repository discovery metadata (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **One-click MCP install badges in the README** (#113): VS Code, VS Code Insiders and Cursor deeplinks that register the server as `ppt-mcp` running the `mcp-ppt` command. Every link was round-trip decoded to confirm it produces exactly `{"name":"ppt-mcp","command":"mcp-ppt"}` before merging, rather than trusting the encoding by eye.
+
 ### Fixed
 
 - **`dotnet pack` on the solution no longer fails, and no longer produces packages that were never meant to ship** (#122): `PptMcp.Core` and `PptMcp.ComInterop` carry a `PackageId` but never set `IsPackable`, so a solution-level pack produced `PptMcp.Core.1.0.0` and `PptMcp.ComInterop.1.0.0` — the exact stale versions sitting orphaned on NuGet while the tools ship 1.1.0. The release workflow packs the two tool projects individually, so nothing was mispublished, but any rewrite towards a solution-level pack would have pushed them, and a higher version number would then have presented them as the current state.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 [![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)](https://github.com/trsdn/mcp-server-ppt)
 [![Built with Copilot](https://img.shields.io/badge/Built%20with-GitHub%20Copilot-0366d6.svg)](https://copilot.github.com/)
 
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522ppt-mcp%2522%252C%2522command%2522%253A%2522mcp-ppt%2522%257D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square)](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522ppt-mcp%2522%252C%2522command%2522%253A%2522mcp-ppt%2522%257D)
+[![Install in Cursor](https://img.shields.io/badge/Cursor-Install_Server-000000?style=flat-square)](https://cursor.com/en/install-mcp?name=ppt-mcp&config=eyJjb21tYW5kIjoibWNwLXBwdCJ9)
+
+> The install badges register the server as `ppt-mcp` running the `mcp-ppt` command. Install the tool
+> first with `dotnet tool install --global PptMcp.McpServer`, otherwise the client has nothing to launch.
+
 **Automate PowerPoint with AI — A Model Context Protocol (MCP) server for comprehensive PowerPoint automation through conversational AI.**
 
 **PptMcp** enables AI assistants such as GitHub Copilot, Claude, and ChatGPT to automate Microsoft PowerPoint through natural language commands. It covers real presentation work end to end: create slides, edit text, place shapes and images, build charts and tables, apply themes, run VBA, export to PDF or video, and manage live PowerPoint windows safely through the native COM API.


### PR DESCRIPTION
Closes #113. Contributes to #101.

## What was wrong

Three separate visibility gaps, none of which needed third-party approval:

1. **The `mcp-server` topic was missing.** It is the most-browsed MCP topic on GitHub, and this repository did not carry it. Nor did `model-context-protocol`, `office-automation` or `pptx`.
2. **`homepageUrl` pointed at the NuGet package page** — a link GitHub already renders in the sidebar, so the slot was wasted.
3. **No install deeplinks.** Every comparable MCP server offers one-click install; this one asked visitors to hand-edit `mcp.json`.

## What changed

**Repository metadata** (applied directly, not in this diff):

| Field | Before | After |
|---|---|---|
| Topics | 10, no `mcp-server` | 16, adds `mcp-server`, `model-context-protocol`, `office-automation`, `pptx`, `presentations`, `cli` |
| Homepage | `nuget.org/packages/PptMcp.McpServer` | `docs/INSTALLATION.md` |

**README** gains VS Code, VS Code Insiders and Cursor install badges.

## Verification of the deeplinks

The issue asked that each deeplink be proven to produce a working config before merging, which matters here because the encoding is genuinely easy to get wrong: the payload is **double** URL-encoded and then embedded in a redirect query parameter. Reading it by eye proves nothing.

Each link was decoded back to its source:

| Badge | Decodes to |
|---|---|
| VS Code | `vscode:mcp/install?{"name":"ppt-mcp","command":"mcp-ppt"}` |
| VS Code Insiders | `vscode-insiders:mcp/install?{"name":"ppt-mcp","command":"mcp-ppt"}` |
| Cursor | base64 `eyJjb21tYW5kIjoibWNwLXBwdCJ9` -> `{"command":"mcp-ppt"}` |

`mcp-ppt` is confirmed as the real entry point — `PptMcp.McpServer.csproj:35` sets `<ToolCommandName>mcp-ppt</ToolCommandName>` — and `ppt-mcp` matches the server name already documented throughout `docs/INSTALLATION.md`.

A deeplink registers a command; it does not install one. If the tool is absent the client fails at first use with nothing to explain why, so a note under the badges states the `dotnet tool install --global PptMcp.McpServer` prerequisite.

## One item in the issue was already resolved

The issue flagged a possibly-dead `https://PptMcpserver.dev/` homepage in `vscode-extension/package.json`. That is stale — all five `package.json` files (`vscode-extension`, `mcpb/manifest.json`, both skill packages, `PptMcp.Agent`) already point at the GitHub repository. No dead link exists.

## Scope

Documentation and repository settings only; no `src/` or `tests/` changes, so the local integration gate does not apply.

The Cursor **directory listing** remains open under #107 — this PR adds the install badge, not the submission.
