### PR TITLE
Add glama.json to claim the Glama.ai listing (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`glama.json` maintainer claim** (#105): declares `trsdn` as maintainer so the Glama.ai listing can be claimed rather than left as an unowned crawl result. The schema at `https://glama.ai/mcp/schemas/server.json` accepts only `maintainers`, so the platform constraint the issue wanted stated there has to live in the README instead.
 - **One-click MCP install badges in the README** (#113): VS Code, VS Code Insiders and Cursor deeplinks that register the server as `ppt-mcp` running the `mcp-ppt` command. Every link was round-trip decoded to confirm it produces exactly `{"name":"ppt-mcp","command":"mcp-ppt"}` before merging, rather than trusting the encoding by eye.
 
 ### Fixed

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "trsdn"
+  ]
+}


### PR DESCRIPTION
Contributes to #105 and #101.

## What this does

Adds `glama.json` declaring `trsdn` as maintainer. Glama crawls public MCP repositories automatically, so a listing exists whether or not we ask for one; this file is what turns an unowned crawl result into a claimed, maintainer-verified entry.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["trsdn"]
}
```

## The schema is much smaller than the issue assumed

The URL the issue cites — `https://glama.ai/mcp/schema.json` — returns **404**. The live schema is at `https://glama.ai/mcp/schemas/server.json`, and it is this, in full:

```json
{
  "properties": {
    "maintainers": {
      "description": "GitHub usernames that have permission to maintain the server",
      "items": { "type": "string" },
      "type": "array",
      "uniqueItems": true
    }
  },
  "required": ["maintainers"],
  "type": "object"
}
```

No description, no platform, no category. `additionalProperties` is not restricted, but inventing fields the platform does not read would be decoration rather than configuration, so the file stays minimal.

## Consequence for the issue's main concern

The issue asked that the description state **Windows-only + PowerPoint required**, so that Glama's automated build and security scans do not score a Linux sandbox COM-interop failure as a broken server. **`glama.json` cannot carry that** — there is no field for it.

The README already leads with it, which is what a crawler actually reads:

> ⚠️ **Windows Only** — COM interop is Windows-specific
> ⚠️ **PowerPoint Required** — Microsoft PowerPoint 2016 or later must be installed

So the constraint is stated; it just cannot be stated where the issue expected.

## What remains open on #105

Both remaining tasks need the Glama site after its next crawl and cannot be done from the repository:

- Verify the listing renders correctly at https://glama.ai/mcp/servers
- Complete the ownership claim if Glama prompts for one

## Scope

One new root file plus a CHANGELOG entry. No `src/` or `tests/` changes, so the local integration gate does not apply.
