### PR TITLE
Ship the MCP server via npx, with no .NET requirement (#110)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,31 @@ jobs:
         Compress-Archive -Path "release/PptMcp-MCP-Server-$version/*" -DestinationPath "PptMcp-MCP-Server-$version-windows.zip"
       shell: pwsh
 
+    # Self-contained build for the npm wrapper (packages/mcp-server-ppt).
+    # The -windows.zip above is framework-dependent and needs the .NET runtime
+    # installed; the whole point of the npm route is that it does not.
+    # The archive name is asserted by that package's `npm test`, so renaming it
+    # here fails a check rather than 404-ing on a user's machine.
+    - name: Create Self-Contained Release Package
+      run: |
+        $version = $env:VERSION
+        dotnet publish src/PptMcp.McpServer/PptMcp.McpServer.csproj `
+          --configuration Release `
+          --runtime win-x64 `
+          --self-contained true `
+          -p:Version=$version -p:AssemblyVersion="$version.0" -p:FileVersion="$version.0" `
+          --output "release/selfcontained-$version"
+        Copy-Item "README.md" "release/selfcontained-$version/"
+        Copy-Item "LICENSE" "release/selfcontained-$version/"
+        Compress-Archive -Path "release/selfcontained-$version/*" -DestinationPath "PptMcp-MCP-Server-$version-win-x64.zip"
+      shell: pwsh
+
+    - name: Upload Self-Contained ZIP Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mcp-server-selfcontained-zip
+        path: PptMcp-MCP-Server-*-win-x64.zip
+
     - name: Upload ZIP Artifact
       uses: actions/upload-artifact@v4
       with:
@@ -546,7 +571,15 @@ jobs:
         }
 
         # Update versions in package.json files
-        foreach ($pkg in @("packages/ppt-mcp-skill/package.json", "packages/ppt-cli-skill/package.json")) {
+        #
+        # mcp-server-ppt is stamped but NOT published by this workflow. It does not
+        # exist on npm yet, and a trusted publisher can only be bound to a package
+        # that already has a version, so the first publish has to be manual (see
+        # docs/RELEASE-STRATEGY.md, "npm publishing"). Stamping it here means that
+        # manual publish, done from a release-tagged checkout, carries the right
+        # version - which matters more for this package than for the skills,
+        # because the wrapper derives its download URL from its own version.
+        foreach ($pkg in @("packages/ppt-mcp-skill/package.json", "packages/ppt-cli-skill/package.json", "packages/mcp-server-ppt/package.json")) {
           $content = Get-Content $pkg -Raw
           $content = $content -replace '"version":\s*"[\d\.]+"', "`"version`": `"$version`""
           Set-Content $pkg $content
@@ -1064,6 +1097,13 @@ jobs:
         dotnet tool install --global PptMcp.CLI
         ```
 
+        **npm / npx** (no .NET required)
+        ```powershell
+        npx -y mcp-server-ppt
+        ```
+        - Downloads the self-contained `PptMcp-MCP-Server-${{ env.VERSION }}-win-x64.zip` below on first run and caches it
+        - Windows x64 only; `npm` refuses to install it elsewhere
+
         **Agent Skills** (for AI coding assistants)
         - VS Code Extension includes both skills automatically (ppt-mcp + ppt-cli)
         ${{ inputs.publish_npm && '- Install via npm: `npx skillpm install ppt-mcp-skill` or `npx skillpm install ppt-cli-skill`' || '' }}
@@ -1083,6 +1123,7 @@ jobs:
         # Collect all artifacts
         ARTIFACTS=""
         for f in artifacts/mcp-server-zip/*.zip; do [ -f "$f" ] && ARTIFACTS="$ARTIFACTS $f"; done
+        for f in artifacts/mcp-server-selfcontained-zip/*.zip; do [ -f "$f" ] && ARTIFACTS="$ARTIFACTS $f"; done
         for f in artifacts/cli-nupkg/*.nupkg; do [ -f "$f" ] && ARTIFACTS="$ARTIFACTS $f"; done
         for f in artifacts/vscode-vsix/*.vsix; do [ -f "$f" ] && ARTIFACTS="$ARTIFACTS $f"; done
         for f in artifacts/mcpb-bundle/*.mcpb; do [ -f "$f" ] && ARTIFACTS="$ARTIFACTS $f"; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`npx -y mcp-server-ppt`: install the MCP server without .NET** (#110): a new npm package, `packages/mcp-server-ppt`, that downloads a self-contained Windows build from the matching GitHub release on first use and caches it under `%LOCALAPPDATA%`. Most MCP clients document `npx` as the default command form, so requiring a .NET tool install was an adoption barrier for anyone who is not a .NET developer.
+  - The name the issue proposed, `ppt-mcp`, is **taken on npm by an unrelated PowerPoint MCP server**. Published as `mcp-server-ppt` instead, matching the repository name, rather than shipping something a user could confuse with someone else's project.
+  - The release workflow now also builds `PptMcp-MCP-Server-<version>-win-x64.zip`, a self-contained publish. The existing `-windows.zip` is framework-dependent and still needs the .NET runtime installed, which would have defeated the point.
+  - Downloads lazily on first run rather than from a `postinstall` hook: npm 12 blocks dependency install scripts by default and `npx` installs this package as a dependency, so a `postinstall` hook is not something that can be relied on. `npx -y mcp-server-ppt --install` pre-warms the cache.
+  - Marked `os: ["win32"]`, `cpu: ["x64"]`, so npm refuses to install it where COM interop cannot exist.
+  - The package is **stamped but not yet published** by the release workflow. It does not exist on npm, and a trusted publisher can only be bound to an existing package, so the first publish has to be manual. See `docs/RELEASE-STRATEGY.md`.
 - **`glama.json` maintainer claim** (#105): declares `trsdn` as maintainer so the Glama.ai listing can be claimed rather than left as an unowned crawl result. The schema at `https://glama.ai/mcp/schemas/server.json` accepts only `maintainers`, so the platform constraint the issue wanted stated there has to live in the README instead.
 - **One-click MCP install badges in the README** (#113): VS Code, VS Code Insiders and Cursor deeplinks that register the server as `ppt-mcp` running the `mcp-ppt` command. Every link was round-trip decoded to confirm it produces exactly `{"name":"ppt-mcp","command":"mcp-ppt"}` before merging, rather than trusting the encoding by eye.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ For multi-phase build / verify / repair workflows from source, the repo also inc
 
 | Platform | Installation |
 |----------|-------------|
-| **Any MCP Client** | `dotnet tool install --global PptMcp.McpServer` |
+| **Any MCP Client (no .NET)** | `npx -y mcp-server-ppt` |
+| **Any MCP Client (.NET tool)** | `dotnet tool install --global PptMcp.McpServer` |
 | **Details** | 📖 [Installation Guide](docs/INSTALLATION.md) |
 
 **⚠️ Important:** Close all PowerPoint files before using. The server requires exclusive access to presentations during automation.
@@ -142,6 +143,10 @@ This package provides both **CLI** and **MCP Server** interfaces. Choose based o
 dotnet tool install --global PptMcp.McpServer
 dotnet tool install --global PptMcp.CLI
 ```
+
+**Without .NET installed:** the MCP server is also published to npm as a wrapper that
+downloads a self-contained build on first use. Point any client at `npx -y mcp-server-ppt`
+instead of `mcp-ppt`. Windows x64 only; the CLI (`pptcli`) remains a .NET tool.
 
 
 ## 🤖 Optional: Official Agent Client from Source

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -63,6 +63,48 @@ That's it! The MCPB bundle includes everything needed - no .NET installation req
 
 ---
 
+## npm / npx Setup (No .NET Required)
+
+**Best for:** anyone who does not already have .NET installed, and any client whose
+documentation defaults to an `npx` command.
+
+```powershell
+npx -y mcp-server-ppt
+```
+
+The wrapper downloads a self-contained build of the MCP server (about 64 MB compressed)
+from the matching GitHub release on first use and caches it under
+`%LOCALAPPDATA%\mcp-server-ppt`. No .NET runtime or SDK is involved.
+
+Point any client's configuration at it:
+
+```json
+{
+  "servers": {
+    "ppt-mcp": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-ppt"]
+    }
+  }
+}
+```
+
+Clients that use the `mcpServers` key instead (Claude Desktop, Cursor, Cline, Windsurf)
+take the same `command` / `args` pair.
+
+To download ahead of time rather than during the first MCP request:
+
+```powershell
+npx -y mcp-server-ppt --install
+```
+
+Windows x64 only — `npm` refuses to install the package on other platforms, because COM
+interop does not exist there. PowerPoint 2016+ is still required. See
+[`packages/mcp-server-ppt/README.md`](https://github.com/trsdn/mcp-server-ppt/blob/main/packages/mcp-server-ppt/README.md)
+for the cache and mirror environment variables.
+
+---
+
 ## Manual MCP Setup (All MCP Clients)
 
 **Best for:** Other MCP clients (Cursor, Windsurf, Cline, Claude Code, Codex), advanced users

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -181,6 +181,34 @@ If a *new* skill package is ever added, break that deadlock outside CI: publish 
 first version manually from a machine that can reach `registry.npmjs.org`, bind a
 trusted publisher to it in the npm UI, and only then wire it into the workflow.
 
+#### `mcp-server-ppt` is stamped but not yet published
+
+`packages/mcp-server-ppt` is the npx wrapper for the MCP server (#110). It is in exactly
+the deadlock described above: it does not exist on npm, so no trusted publisher can be
+bound to it, so the workflow cannot publish it. It is therefore **version-stamped by the
+release workflow but deliberately absent from the publish job** — adding it there would
+trip the preflight and fail every release until the package existed.
+
+Version stamping matters more for this package than for the skills: the wrapper builds
+its download URL from its own version, so a mis-stamped package would ask GitHub for a
+release asset that does not exist.
+
+To bootstrap it, from a machine that can reach `registry.npmjs.org`:
+
+```powershell
+git checkout v<version>          # so package.json carries the release version
+cd packages/mcp-server-ppt
+npm publish --access public
+```
+
+Then bind a trusted publisher (repository `trsdn/mcp-server-ppt`, workflow `release.yml`)
+in the npm UI, add the package to the preflight list and to a `npm publish --provenance
+--access public` step in the `publish` job.
+
+The wrapper depends on the `PptMcp-MCP-Server-<version>-win-x64.zip` release asset built
+by the `build-mcp-server` job. That asset name is asserted by `npm test` in the package,
+so renaming it on either side fails a check instead of 404-ing on a user's machine.
+
 Do not try to publish from a corporate workstation. `registry.npmjs.org` is not
 reachable here: it fails during the TLS handshake, while the configured mirror
 `packagefeedproxy.microsoft.io` answers normally. Publishing only works from the

--- a/packages/mcp-server-ppt/README.md
+++ b/packages/mcp-server-ppt/README.md
@@ -1,0 +1,85 @@
+# mcp-server-ppt
+
+MCP server for Microsoft PowerPoint automation through PowerPoint's own COM API.
+
+```powershell
+npx -y mcp-server-ppt
+```
+
+No .NET SDK or runtime required — the wrapper downloads a self-contained build.
+
+## Requirements
+
+- **Windows x64.** `npm` refuses to install this package anywhere else, because
+  COM interop does not exist on other platforms.
+- **Microsoft PowerPoint 2016 or later**, installed locally. This server drives the
+  real application; it is not a file-format library.
+
+## Client configuration
+
+VS Code (`.vscode/mcp.json`) or Visual Studio (`.mcp.json`):
+
+```json
+{
+  "servers": {
+    "ppt-mcp": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-ppt"]
+    }
+  }
+}
+```
+
+Claude Desktop, Cursor, Cline, Windsurf:
+
+```json
+{
+  "mcpServers": {
+    "ppt-mcp": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-ppt"]
+    }
+  }
+}
+```
+
+## How the install works
+
+On first run the wrapper downloads `PptMcp-MCP-Server-<version>-win-x64.zip` from the
+matching GitHub release and extracts it to
+`%LOCALAPPDATA%\mcp-server-ppt\runtime-<version>`. Subsequent runs reuse it. The
+download is roughly 64 MB compressed, 145 MB once extracted, and happens once per
+version.
+
+Downloading lazily rather than in a `postinstall` hook is deliberate: npm 12 blocks
+dependency install scripts by default, and `npx` installs this package as a dependency
+of a temporary root, so a `postinstall` hook is not something that can be relied on.
+Resolving inside `bin` always runs.
+
+To download ahead of time instead of on the first MCP request:
+
+```powershell
+npx -y mcp-server-ppt --install
+```
+
+If extraction or download fails, the partially populated directory is removed rather
+than left behind — otherwise the next run would find no executable, re-download, and
+`Expand-Archive -Force` would merge the two trees.
+
+### Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `MCP_SERVER_PPT_HOME` | Use an existing extracted build at this path and skip the download entirely. |
+| `MCP_SERVER_PPT_CACHE` | Base directory for the cached runtime. Defaults to `%LOCALAPPDATA%\mcp-server-ppt`. |
+| `MCP_SERVER_PPT_ASSET_URL` | Download from somewhere other than the GitHub release, for mirrors and testing. |
+
+## Other ways to install
+
+- **.NET tool:** `dotnet tool install --global PptMcp.McpServer`
+- **VS Code extension**, **Claude Desktop MCPB bundle**, and direct release downloads:
+  see the [main README](https://github.com/trsdn/mcp-server-ppt).
+
+## Licence
+
+MIT. Source: https://github.com/trsdn/mcp-server-ppt

--- a/packages/mcp-server-ppt/bin/mcp-server-ppt.js
+++ b/packages/mcp-server-ppt/bin/mcp-server-ppt.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+'use strict';
+
+// stdout belongs to the MCP transport. Diagnostics go to stderr, always.
+
+const { spawn } = require('child_process');
+const { ensureRuntime, packageVersion } = require('../lib/runtime');
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args[0] === '--install') {
+    const exe = await ensureRuntime();
+    process.stderr.write(`[mcp-server-ppt] ready: ${exe}\n`);
+    return 0;
+  }
+
+  if (args[0] === '--version') {
+    process.stderr.write(`mcp-server-ppt ${packageVersion()}\n`);
+    return 0;
+  }
+
+  const exe = await ensureRuntime();
+
+  const child = spawn(exe, args, { stdio: 'inherit', windowsHide: true });
+
+  // Forward termination so a client killing the wrapper does not strand a
+  // PowerPoint-owning server process.
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.on(signal, () => {
+      if (!child.killed) {
+        child.kill();
+      }
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('exit', (code, signal) => resolve(signal ? 1 : code === null ? 1 : code));
+  });
+}
+
+main().then(
+  (code) => {
+    process.exitCode = code;
+  },
+  (error) => {
+    process.stderr.write(`[mcp-server-ppt] ${error.message}\n`);
+    process.exitCode = 1;
+  }
+);

--- a/packages/mcp-server-ppt/lib/runtime.js
+++ b/packages/mcp-server-ppt/lib/runtime.js
@@ -1,0 +1,191 @@
+'use strict';
+
+// Resolves the PptMcp MCP server binary, downloading the self-contained Windows
+// build from the matching GitHub release on first use.
+//
+// Download is lazy rather than a postinstall hook on purpose. npm 12 blocks
+// dependency install scripts by default, and `npx` installs this package as a
+// dependency of a temporary root, so a postinstall hook is not something we can
+// rely on continuing to run. Resolving in `bin` always runs.
+//
+// Everything this module prints goes to stderr. stdout is the MCP transport.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+const { spawnSync } = require('child_process');
+
+const REPO = 'trsdn/mcp-server-ppt';
+const EXE_NAME = 'PptMcp.McpServer.exe';
+
+function packageVersion() {
+  return require('../package.json').version;
+}
+
+function assetName(version = packageVersion()) {
+  return `PptMcp-MCP-Server-${version}-win-x64.zip`;
+}
+
+function assetUrl(version = packageVersion()) {
+  if (process.env.MCP_SERVER_PPT_ASSET_URL) {
+    return process.env.MCP_SERVER_PPT_ASSET_URL;
+  }
+  return `https://github.com/${REPO}/releases/download/v${version}/${assetName(version)}`;
+}
+
+function installRoot(version) {
+  const base =
+    process.env.MCP_SERVER_PPT_CACHE ||
+    path.join(process.env.LOCALAPPDATA || os.tmpdir(), 'mcp-server-ppt');
+  return path.join(base, `runtime-${version}`);
+}
+
+function log(message) {
+  process.stderr.write(`[mcp-server-ppt] ${message}\n`);
+}
+
+function download(url, destination, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'user-agent': `mcp-server-ppt/${packageVersion()}` } }, (response) => {
+        const status = response.statusCode;
+
+        if (status >= 300 && status < 400 && response.headers.location) {
+          response.resume();
+          if (redirectsLeft === 0) {
+            reject(new Error(`Too many redirects while downloading ${url}`));
+            return;
+          }
+          resolve(download(new URL(response.headers.location, url).toString(), destination, redirectsLeft - 1));
+          return;
+        }
+
+        if (status !== 200) {
+          response.resume();
+          reject(new Error(`Download failed with HTTP ${status}: ${url}`));
+          return;
+        }
+
+        const total = Number(response.headers['content-length']) || 0;
+        let received = 0;
+        let lastReport = 0;
+
+        const file = fs.createWriteStream(destination);
+        response.on('data', (chunk) => {
+          received += chunk.length;
+          const now = Date.now();
+          if (total && now - lastReport > 2000) {
+            lastReport = now;
+            log(`downloading ${Math.round((received / total) * 100)}%`);
+          }
+        });
+        response.pipe(file);
+        file.on('finish', () => file.close(() => resolve(destination)));
+        file.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+// Windows-only package, so PowerShell is always available and this stays
+// dependency-free. Node has no built-in zip reader.
+function extract(archive, destination) {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      `Expand-Archive -LiteralPath '${archive.replace(/'/g, "''")}' -DestinationPath '${destination.replace(/'/g, "''")}' -Force`,
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  );
+
+  if (result.status !== 0) {
+    const detail = (result.stderr || '').toString().trim();
+    throw new Error(`Failed to extract ${archive}${detail ? `: ${detail}` : ''}`);
+  }
+}
+
+function assertLooksLikeZip(file) {
+  const size = fs.statSync(file).size;
+  if (size < 1024 * 1024) {
+    throw new Error(
+      `Downloaded archive is only ${size} bytes, which cannot be a self-contained build. ` +
+        'The release asset is probably missing.'
+    );
+  }
+  const header = Buffer.alloc(2);
+  const fd = fs.openSync(file, 'r');
+  try {
+    fs.readSync(fd, header, 0, 2, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  if (header[0] !== 0x50 || header[1] !== 0x4b) {
+    throw new Error('Downloaded file is not a ZIP archive. The release asset URL may be wrong.');
+  }
+}
+
+async function ensureRuntime() {
+  if (process.platform !== 'win32') {
+    throw new Error(
+      'mcp-server-ppt only runs on Windows: it drives PowerPoint through the native COM API.'
+    );
+  }
+
+  if (process.env.MCP_SERVER_PPT_HOME) {
+    const local = path.join(process.env.MCP_SERVER_PPT_HOME, EXE_NAME);
+    if (!fs.existsSync(local)) {
+      throw new Error(`MCP_SERVER_PPT_HOME is set but ${local} does not exist.`);
+    }
+    return local;
+  }
+
+  const version = packageVersion();
+  const root = installRoot(version);
+  const exe = path.join(root, EXE_NAME);
+
+  if (fs.existsSync(exe)) {
+    return exe;
+  }
+
+  const url = assetUrl(version);
+  log(`installing the PowerPoint MCP server ${version} (about 64 MB to download, 145 MB on disk, one time)`);
+  log(`source: ${url}`);
+
+  fs.mkdirSync(root, { recursive: true });
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-server-ppt-'));
+  const archive = path.join(staging, assetName(version));
+
+  try {
+    await download(url, archive);
+    assertLooksLikeZip(archive);
+    extract(archive, root);
+
+    if (!fs.existsSync(exe)) {
+      throw new Error(`Archive extracted but ${EXE_NAME} was not found in it.`);
+    }
+    log('install complete');
+    return exe;
+  } catch (error) {
+    // Never leave a half-extracted directory behind: the next run would find no
+    // exe, re-download, and Expand-Archive -Force would merge the two.
+    fs.rmSync(root, { recursive: true, force: true });
+    throw error;
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+module.exports = {
+  EXE_NAME,
+  assetName,
+  assetUrl,
+  ensureRuntime,
+  installRoot,
+  packageVersion,
+};

--- a/packages/mcp-server-ppt/lib/selftest.js
+++ b/packages/mcp-server-ppt/lib/selftest.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// Network-free checks for the wrapper. Run with `npm test` in this directory.
+//
+// The check that matters is the last one: the asset name this wrapper requests
+// has to match the asset name the release workflow produces. Those two strings
+// live in different files, in different languages, and nothing else connects
+// them, so a rename on either side would only ever surface as a 404 on a user's
+// machine after publish.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const runtime = require('./runtime');
+const pkg = require('../package.json');
+
+const failures = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`  ok   ${name}\n`);
+  } catch (error) {
+    failures.push(name);
+    process.stdout.write(`  FAIL ${name}\n         ${error.message}\n`);
+  }
+}
+
+check('package declares Windows-only so npm refuses other platforms', () => {
+  assert.deepStrictEqual(pkg.os, ['win32']);
+  assert.deepStrictEqual(pkg.cpu, ['x64']);
+});
+
+check('every file listed in "files" exists', () => {
+  for (const entry of pkg.files) {
+    const target = path.join(__dirname, '..', entry);
+    if (entry === 'README.md' && !fs.existsSync(target)) {
+      throw new Error('README.md is missing');
+    }
+    if (entry !== 'README.md') {
+      assert.ok(fs.existsSync(target), `${entry} is missing`);
+    }
+  }
+});
+
+check('bin entry point exists and is executable JavaScript', () => {
+  const bin = path.join(__dirname, '..', pkg.bin['mcp-server-ppt']);
+  assert.ok(fs.existsSync(bin), `${bin} is missing`);
+  assert.ok(fs.readFileSync(bin, 'utf8').startsWith('#!/usr/bin/env node'));
+});
+
+check('asset URL points at this package version in this repository', () => {
+  const url = runtime.assetUrl();
+  assert.ok(url.startsWith('https://github.com/trsdn/mcp-server-ppt/releases/download/v'), url);
+  assert.ok(url.includes(pkg.version), url);
+});
+
+check('MCP_SERVER_PPT_ASSET_URL overrides the default source', () => {
+  process.env.MCP_SERVER_PPT_ASSET_URL = 'https://example.invalid/x.zip';
+  try {
+    assert.strictEqual(runtime.assetUrl(), 'https://example.invalid/x.zip');
+  } finally {
+    delete process.env.MCP_SERVER_PPT_ASSET_URL;
+  }
+});
+
+check('asset name matches the archive the release workflow builds', () => {
+  const workflow = path.join(__dirname, '..', '..', '..', '.github', 'workflows', 'release.yml');
+  if (!fs.existsSync(workflow)) {
+    // Running from an installed package rather than the repository.
+    return;
+  }
+  const contents = fs.readFileSync(workflow, 'utf8');
+  const expected = runtime.assetName('$version');
+  assert.ok(
+    contents.includes(expected),
+    `release.yml does not produce "${expected}" - the wrapper would download a 404`
+  );
+});
+
+process.stdout.write(failures.length ? `\n${failures.length} check(s) failed\n` : '\nall checks passed\n');
+process.exitCode = failures.length ? 1 : 0;

--- a/packages/mcp-server-ppt/package.json
+++ b/packages/mcp-server-ppt/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "mcp-server-ppt",
+  "version": "0.0.0",
+  "description": "MCP server for Microsoft PowerPoint automation via the native COM API. Windows only, requires PowerPoint 2016+.",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "powerpoint",
+    "pptx",
+    "office-automation",
+    "presentations",
+    "windows"
+  ],
+  "homepage": "https://github.com/trsdn/mcp-server-ppt",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trsdn/mcp-server-ppt.git",
+    "directory": "packages/mcp-server-ppt"
+  },
+  "bugs": {
+    "url": "https://github.com/trsdn/mcp-server-ppt/issues"
+  },
+  "author": "trsdn",
+  "license": "MIT",
+  "type": "commonjs",
+  "bin": {
+    "mcp-server-ppt": "bin/mcp-server-ppt.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "dependencies": {},
+  "scripts": {
+    "test": "node lib/selftest.js"
+  }
+}


### PR DESCRIPTION
Closes #110. Contributes to #101.

## Why

Nearly every MCP client's documentation defaults to an `npx` command. Requiring `dotnet tool install` was a real adoption barrier for anyone who is not a .NET developer — the issue calls this the single highest-leverage item in #101.

```powershell
npx -y mcp-server-ppt
```

## Three findings that changed the shape of this

**1. The name the issue proposed is taken.** `ppt-mcp` on npm is an **unrelated** pure-Node PowerPoint MCP server ([guangxiangdebizi/ppt-mcp](https://github.com/guangxiangdebizi/ppt-mcp), v2.0.0). Publishing there would have put users one namespace collision away from installing the wrong project. Published as **`mcp-server-ppt`**, matching the repository name. Verified free via `npm view`.

> An earlier availability probe reported all four candidate names as free. That probe was wrong — it was reporting TLS handshake failures as 404s, and said `express` was available too. Re-checked with `npm view`.

**2. The existing release asset would not have removed the .NET requirement.** `PptMcp-MCP-Server-<version>-windows.zip` is a plain `dotnet build` output — framework-dependent, so it still needs the .NET runtime installed. Downloading that would have moved the barrier from SDK to runtime rather than removing it.

The `build-mcp-server` job now also produces `PptMcp-MCP-Server-<version>-win-x64.zip` from a genuine `--self-contained` publish. Measured locally: **64 MB compressed, 144 MB on disk, 500 files.**

**3. A `postinstall` hook is not reliable here.** npm 12 blocks dependency install scripts by default — this repository already pins `npm@^11.5.1` for exactly that reason — and `npx` installs this package as a dependency of a temporary root. So the download happens lazily inside `bin`, which always runs. `npx -y mcp-server-ppt --install` pre-warms the cache for anyone who would rather not wait during their first MCP request.

## The cross-file invariant, and why `npm test` exists

The wrapper's asset name and the workflow's archive name are two strings, in two files, in two languages, with nothing connecting them. A rename on either side would only ever surface as a **404 on a user's machine after publish**.

`npm test` reads `release.yml` and asserts the names match. It also caught a real bug while being written: `assetUrl()` had no default for its `version` parameter, so `bin` would have requested `.../download/vundefined/PptMcp-MCP-Server-undefined-win-x64.zip`.

## Verification

| Check | Result |
|---|---|
| Self-contained publish starts and completes an MCP `initialize` handshake | **PASS** — `serverInfo.version` reflects the stamped version |
| Real HTTPS download, through GitHub's redirect to `objects.githubusercontent.com`, extract, locate exe | **PASS** (exercised against the real v1.0.3 release asset) |
| `initialize` handshake through `node bin/mcp-server-ppt.js`, stdout clean, diagnostics on stderr | **PASS** |
| Failure path: HTTP 404 | exit 1, **no leftover cache directory** |
| Failure path: response is not an archive | exit 1, **no leftover cache directory** |
| `npm test` | 6/6 checks pass |
| `release.yml` still parses | PASS — 10 jobs |
| `npm pack --dry-run` | 5 files, 5.2 kB |

The cleanup on failure is not incidental. Without it the next run would find no executable, re-download, and `Expand-Archive -Force` would merge the new tree into the broken one.

## Deliberately not wired into the publish job

`mcp-server-ppt` does not exist on npm, and a trusted publisher can only be bound to a package that already exists. The `publish` job's preflight **fails the release** when asked to publish a package that is absent — so wiring it in now would break every release until the package existed.

It is therefore **version-stamped but not published**. Stamping matters more here than for the skill packages, because the wrapper derives its download URL from its own version. The manual bootstrap is documented in `docs/RELEASE-STRATEGY.md`, following the process that file already prescribes for new packages.

**This means #110 is not fully live until the owner runs one manual `npm publish`.** Everything else is in place.

## Files

- `packages/mcp-server-ppt/` — new package (`package.json`, `bin/`, `lib/runtime.js`, `lib/selftest.js`, `README.md`)
- `.github/workflows/release.yml` — self-contained publish + zip, artifact upload, release asset, version stamping, release notes
- `README.md`, `docs/INSTALLATION.md` — npx install path and client config examples
- `docs/RELEASE-STRATEGY.md` — bootstrap procedure
- `CHANGELOG.md`

## Scope

No `src/` or `tests/` changes, so the local integration gate does not apply. The self-contained publish was nevertheless built and run locally, since that is the load-bearing claim.
