### PR TITLE
Stop publishing a registry entry that points at a four-release-old package (#108)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,10 +617,32 @@ jobs:
       run: |
         $version = $env:VERSION
         $serverJsonPath = "src/PptMcp.McpServer/.mcp/server.json"
-        $serverContent = Get-Content $serverJsonPath -Raw
-        $serverContent = $serverContent -replace '("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")' , "`$1`"$version`"`$2"
-        $serverContent = $serverContent -replace '("identifier":\s*"Trsdn\.PptMcp\.McpServer",\s*\n\s*"version":\s*)"[\d\.]+"', "`$1`"$version`""
-        Set-Content $serverJsonPath $serverContent
+
+        # Parse the document instead of pattern-matching it. The previous version used
+        # two regexes; the second looked for an identifier of "Trsdn.PptMcp.McpServer",
+        # but the file has only ever said "PptMcp.McpServer". It therefore never matched,
+        # and every release published a registry entry pinning the NuGet package at
+        # 1.0.0 - confirmed live for 1.0.1, 1.0.2, 1.0.3 and 1.1.0.
+        $server = Get-Content $serverJsonPath -Raw | ConvertFrom-Json
+        $server.version = $version
+        foreach ($pkg in $server.packages) { $pkg.version = $version }
+        $server | ConvertTo-Json -Depth 10 | Set-Content $serverJsonPath -Encoding utf8
+
+        # A stamp that quietly does nothing is precisely the failure being fixed here,
+        # so read the file back and fail loudly if any version did not take.
+        $check = Get-Content $serverJsonPath -Raw | ConvertFrom-Json
+        if (-not $check.packages -or @($check.packages).Count -eq 0) {
+          throw "server.json lists no packages - nothing was stamped"
+        }
+        if ($check.version -ne $version) {
+          throw "server.json version is '$($check.version)', expected '$version'"
+        }
+        foreach ($pkg in $check.packages) {
+          if ($pkg.version -ne $version) {
+            throw "package '$($pkg.identifier)' version is '$($pkg.version)', expected '$version'"
+          }
+        }
+        Write-Output "Stamped server.json and $(@($check.packages).Count) package(s) to $version"
       shell: pwsh
 
     - name: Wait for NuGet Propagation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+### Fixed
+
+- **The MCP Registry no longer advertises a stale NuGet package version** (#108): every registry entry we have ever published — 1.0.1, 1.0.2, 1.0.3 and the current `isLatest` 1.1.0 — tells clients to install `PptMcp.McpServer` **1.0.0**. Anyone discovering the server through `registry.modelcontextprotocol.io` therefore got a build four releases behind, while the entry itself claimed to be the current version.
+  - `server.json` carries the version twice: once for the server, once inside `packages[]` for the artifact to install. The release workflow stamped them with two separate regexes, and the one targeting the package version searched for an identifier of `Trsdn.PptMcp.McpServer`. The file has only ever said `PptMcp.McpServer`, so that regex could never match. It failed silently and the release continued.
+  - The step now parses the JSON, updates every `packages[].version`, then reads the file back and throws if any version did not take or if the package list is empty. The previous behaviour was a stamp that reported success while doing nothing, which is exactly the failure mode the repository's other gates are written to avoid.
+  - Also added `runtimeHint: "dnx"` so clients know how to launch the .NET tool, and corrected the stale example in `docs/MCP_REGISTRY_PUBLISHING.md`, which still showed the October schema revision and a `description` that no longer matched the shipped file.
+  - Existing published entries are immutable; the correction takes effect from the next release.
+
 - **`dotnet pack` on the solution no longer fails, and no longer produces packages that were never meant to ship** (#122): `PptMcp.Core` and `PptMcp.ComInterop` carry a `PackageId` but never set `IsPackable`, so a solution-level pack produced `PptMcp.Core.1.0.0` and `PptMcp.ComInterop.1.0.0` — the exact stale versions sitting orphaned on NuGet while the tools ship 1.1.0. The release workflow packs the two tool projects individually, so nothing was mispublished, but any rewrite towards a solution-level pack would have pushed them, and a higher version number would then have presented them as the current state.
   - Both are implementation details rather than a public contract. Their interfaces carry **220 `[ServiceAction]` methods**, each generating exactly one CLI command and one MCP tool, so every new tool would be a breaking change on a published API. `PptMcp.Service` and `PptMcp.Build.Tasks` already set `IsPackable=false` for the same reason; these two were the outliers.
   - Nothing depends on them being packable: `PptMcp.CLI` and `PptMcp.McpServer` are both `PackAsTool`, so they bundle these assemblies inside the tool package rather than taking a NuGet dependency on them.

--- a/docs/MCP_REGISTRY_PUBLISHING.md
+++ b/docs/MCP_REGISTRY_PUBLISHING.md
@@ -18,19 +18,22 @@ This is the MCP registry metadata file that describes the server:
 
 ```json
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.trsdn/mcp-server-ppt",
-  "title": "PowerPoint COM Automation",
-  "description": "PowerPoint COM automation - Slides, shapes, text, charts, tables, animations, transitions, VBA",
-  "version": "1.0.0",
+  "title": "MCP Server for PowerPoint",
+  "description": "PowerPoint automation for AI - Slides, Shapes, Text, Charts and more. Windows only.",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "PptMcp.McpServer",
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [],
+      "environmentVariables": []
     }
   ],
   "repository": {
@@ -43,9 +46,30 @@ This is the MCP registry metadata file that describes the server:
 Key fields:
 - `name`: Registry namespace (uses GitHub namespace `io.github.trsdn/*`)
 - `title`: Human-readable name
-- `description`: Brief description of capabilities
-- `version`: Server version (automatically updated by release workflow)
-- `packages`: Array of deployment options (NuGet package in this case)
+- `description`: Brief description of capabilities. **The schema caps this at 100
+  characters** - a longer string is rejected at publish time, so it cannot simply
+  mirror the much longer NuGet `<Description>`.
+- `version`: Server version (stamped by the release workflow)
+- `packages`: Array of deployment options (NuGet package in this case).
+  `runtimeHint: "dnx"` tells clients how to launch the .NET tool.
+
+### Both version fields are stamped, and the stamp is checked
+
+`server.json` carries the version twice: once at the top level for the server, and
+once inside each `packages[]` entry for the artifact to install. **Both** must be
+updated at release time, and they are independent - a release can publish a correct
+server version while pointing clients at a stale package.
+
+That is not hypothetical. The stamping step originally used two regexes, and the one
+targeting the package version searched for an identifier of `Trsdn.PptMcp.McpServer`
+while the file has only ever said `PptMcp.McpServer`. It never matched, silently, so
+releases 1.0.1, 1.0.2, 1.0.3 and 1.1.0 all published registry entries pinning the
+NuGet package at `1.0.0`.
+
+The step now parses the JSON, updates every `packages[].version`, then reads the file
+back and throws if any version did not take or if the package list is empty. A stamp
+that quietly does nothing was the entire defect, so it must not be able to report
+success without evidence.
 
 ### Package Validation
 

--- a/src/PptMcp.McpServer/.mcp/server.json
+++ b/src/PptMcp.McpServer/.mcp/server.json
@@ -3,12 +3,13 @@
   "name": "io.github.trsdn/mcp-server-ppt",
   "title": "MCP Server for PowerPoint",
   "description": "PowerPoint automation for AI - Slides, Shapes, Text, Charts and more. Windows only.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "PptMcp.McpServer",
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## The problem

Every MCP Registry entry this project has published points clients at **`PptMcp.McpServer` 1.0.0**. Queried live just now:

```
GET https://registry.modelcontextprotocol.io/v0/servers?search=io.github.trsdn/mcp-server-ppt
```

| Entry version | Advertised package version | `isLatest` |
| --- | --- | --- |
| 1.0.1 | `1.0.0` | false |
| 1.0.2 | `1.0.0` | false |
| 1.0.3 | `1.0.0` | false |
| **1.1.0** | **`1.0.0`** | **true** |

So the current entry describes itself as 1.1.0 while handing out a build four releases behind. Anyone who discovers this server through the official registry — which is now *the* discovery path, see below — installs a stale version and has no way to tell.

## What the old code claimed

`server.json` carries the version twice: once at the top level for the server, and once inside `packages[]` for the artifact to install. They are independent, and both have to be stamped.

The release workflow stamped them with two regexes:

```powershell
$serverContent = $serverContent -replace '("version":\s*)"[\d\.]+"(\s*,\s*\n\s*"packages")' , ...
$serverContent = $serverContent -replace '("identifier":\s*"Trsdn\.PptMcp\.McpServer",\s*\n\s*"version":\s*)"[\d\.]+"', ...
```

The second one searches for an identifier of `Trsdn.PptMcp.McpServer`. The file has only ever said `PptMcp.McpServer`. It could never match — and `-replace` returns the input unchanged when it doesn't match, so the step wrote the file back, exited 0, and the release proceeded.

## The fix

Parse the document instead of pattern-matching it, and then verify the stamp actually landed:

```powershell
$server = Get-Content $serverJsonPath -Raw | ConvertFrom-Json
$server.version = $version
foreach ($pkg in $server.packages) { $pkg.version = $version }
$server | ConvertTo-Json -Depth 10 | Set-Content $serverJsonPath -Encoding utf8

$check = Get-Content $serverJsonPath -Raw | ConvertFrom-Json
if (-not $check.packages -or @($check.packages).Count -eq 0) { throw ... }
if ($check.version -ne $version) { throw ... }
foreach ($pkg in $check.packages) { if ($pkg.version -ne $version) { throw ... } }
```

The read-back is the point. A stamp that reports success while doing nothing is the entire defect here, and it matches the standard the repo already applies to its other gates — *a gate that finds nothing must fail*. This one now cannot pass without evidence, and it covers any future package entry rather than one hardcoded identifier.

## Evidence

Verified locally against the real file, since the workflow itself cannot be run here.

| Check | Result |
| --- | --- |
| New logic stamps top-level **and** package version | PASS (both → `9.9.9`) |
| `$schema`, `identifier`, `transport`, `repository` survive the round-trip | PASS |
| **Old regex applied to the same file** | **document byte-identical — the bug, reproduced** |
| `release.yml` parses (`yaml.safe_load`) | PASS, 10 jobs |
| `server.json` validates against live `2025-12-11` schema | PASS |
| `description` within schema cap | 83/100 |
| Pre-commit gates | all 8 passed |

The reproduction line matters most: it confirms the diagnosis rather than just asserting it.

## Also in this change

- **`runtimeHint: "dnx"`** on the package, so clients know how to launch the .NET tool.
- **Committed `server.json` moved to 1.1.0.** It said 1.0.0, which was indistinguishable from the bug's output.
- **`docs/MCP_REGISTRY_PUBLISHING.md`** — its example still showed the `2025-10-17` schema revision and a `title`/`description` that no longer matched the shipped file. Now synced, with the failure documented so the two-fields-not-one shape is not re-learned the hard way.
- Documented that the schema **caps `description` at 100 characters**, which is why it cannot mirror the much longer NuGet `<Description>`.

## What remains

Published registry entries are immutable, so the four existing ones keep pointing at 1.0.0. The correction takes effect from the next release.

Worth noting for this issue's original scope: the community list in `modelcontextprotocol/servers` has been **retired**, and their CONTRIBUTING now says they *"don't accept new server implementations"* — so the PR this issue asked for is not possible. The registry that replaced it is the channel this PR fixes, and we were already publishing to it.
