### PR TITLE
Describe the npm registry block as policy, not a network fault

### DIFF
--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -209,11 +209,13 @@ The wrapper depends on the `PptMcp-MCP-Server-<version>-win-x64.zip` release ass
 by the `build-mcp-server` job. That asset name is asserted by `npm test` in the package,
 so renaming it on either side fails a check instead of 404-ing on a user's machine.
 
-Do not try to publish from a corporate workstation. `registry.npmjs.org` is not
-reachable here: it fails during the TLS handshake, while the configured mirror
-`packagefeedproxy.microsoft.io` answers normally. Publishing only works from the
-runner. The same mirror also serves `npm view`, so a freshly published version may not
-show up there for a while - confirm a publish on npmjs.com, not through the mirror.
+Do not try to publish from a corporate workstation, and do not try to work around it.
+Access to `registry.npmjs.org` is blocked **by design** - the connection fails during
+the TLS handshake, while the configured mirror `packagefeedproxy.microsoft.io` answers
+normally. This is policy, not a transient fault, so it is not something to retry or
+route around: publishing has to happen from the runner or another sanctioned
+environment. The same mirror also serves `npm view`, so a freshly published version may
+not show up there for a while - confirm a publish on npmjs.com, not through the mirror.
 The provenance attestation is a mirror-independent proof that a publish happened:
 
 ```powershell


### PR DESCRIPTION
The npm publishing section in `docs/RELEASE-STRATEGY.md` said `registry.npmjs.org` *"is not reachable here"* and explained the TLS handshake failure.

That reads as an environmental defect, which invites the next person to retry it, try a different transport, or otherwise route around it. I had written it that way after observing the failure, without knowing the cause.

It is deliberate: public package registry access, including npm locally, is blocked **by design** on the corporate workstation. Saying so plainly is the more useful instruction, because the correct response is to publish from the runner or another sanctioned environment rather than to work the block.

No behaviour change - documentation wording only.

### Checked while here

The product's own update check (`NuGetVersionChecker`) hits `api.nuget.org`, so it is worth recording that it degrades correctly in a blocked environment: a 5s `HttpClient` timeout, a catch-all returning `null`, and callers that treat `null` as *no update info*. It is **not** on the per-command path - only `pptcli --version` and a background tray task call it - so blocked networks pay no per-invocation penalty.

`docs/PRIVACY.md` notes there is no setting to disable that check. In an environment where the endpoint is blocked as policy, an opt-out env var would be a reasonable small addition, but that is a product decision rather than something to slip into a docs fix, so I have left it alone.