### PR TITLE
fix: stop theme colour reads returning a silently short palette (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Theme colour reads could return a silently incomplete palette** (#126): `DesignCommands.GetColors` builds its twelve-entry colour map one read at a time, each wrapped in a catch-all. A failed read simply **omitted its key**, so the caller got a shorter map rather than an error — and the result still carried `Success = true`. Callers index this map by name, so a missing `Accent3` reads as a theme that has no `Accent3`.
+  - The same catch hid a **COM leak**: `ComUtilities.Release(ref colorItem!)` was the last statement *inside* the `try`, so any failing read skipped it. Restructured to acquire before the `try` and release in a `finally`.
+  - Added `DesignColorRoundTripTests`, which pins the **exact twelve-key set** rather than a count — a walk that dropped one role would still satisfy "at least eight colours" — and validates every value as `#RRGGBB`. Confirmed passing against the unmodified code before the catch was removed.
+  - `scripts/swallowed-catches-baseline.txt` lowered from 12 to 11.
+
 - **The accessibility audit could report findings that were not true, and miss ones that were** (#126): `AccessibilityCommands.AuditSlide` wrapped both of its enumeration loops in catch-alls, and a failure part-way through either produced a *plausible* wrong answer while the result still carried `Success = true`.
   - The placeholder walk sets `hasTitle`. Aborting before it reached the title placeholder left that false, so the audit reported **`MissingTitle` for a slide that has a title** — a fabricated finding, presented as fact. A swallowed text read did the same for `EmptyTitlePlaceholder`.
   - The shape walk is what raises `MissingAltText`. Aborting mid-walk silently dropped every remaining finding, so the audit **under-reported**. That is the worse direction: a user acts on "No accessibility issues found." and ships an inaccessible deck.

--- a/scripts/swallowed-catches-baseline.txt
+++ b/scripts/swallowed-catches-baseline.txt
@@ -1,6 +1,5 @@
 src/PptMcp.Core/Commands/Background/BackgroundCommands.cs:39
-src/PptMcp.Core/Commands/Design/DesignCommands.cs:114
-src/PptMcp.Core/Commands/Design/DesignCommands.cs:163
+src/PptMcp.Core/Commands/Design/DesignCommands.cs:165
 src/PptMcp.Core/Commands/DocumentProperty/DocumentPropertyCommands.cs:105
 src/PptMcp.Core/Commands/DocumentProperty/DocumentPropertyCommands.cs:160
 src/PptMcp.Core/Commands/DocumentProperty/DocumentPropertyCommands.cs:87

--- a/src/PptMcp.Core/Commands/Design/DesignCommands.cs
+++ b/src/PptMcp.Core/Commands/Design/DesignCommands.cs
@@ -100,18 +100,20 @@ public partial class DesignCommands : IDesignCommands
 
                 for (int i = 1; i <= Math.Min(12, colorNames.Length); i++)
                 {
+                    dynamic colorItem = colorScheme.Colors(i);
                     try
                     {
-                        dynamic colorItem = colorScheme.Colors(i);
                         int rgb = (int)colorItem.RGB;
                         // COM returns BGR, convert to #RRGGBB
                         int r = rgb & 0xFF;
                         int g = (rgb >> 8) & 0xFF;
                         int b = (rgb >> 16) & 0xFF;
                         colors[colorNames[i - 1]] = $"#{r:X2}{g:X2}{b:X2}";
+                    }
+                    finally
+                    {
                         ComUtilities.Release(ref colorItem!);
                     }
-                    catch { }
                 }
 
                 return new ThemeColorResult

--- a/tests/PptMcp.Core.Tests/Integration/DesignColorRoundTripTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/DesignColorRoundTripTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Design;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for theme and colour-scheme reads (GitHub #126).
+///
+/// <c>DesignCommands.GetColors</c> and <c>ListColorSchemes</c> both build a dictionary of
+/// named colours one entry at a time, with each read wrapped in a catch-all. A failed read
+/// simply omitted its key, so the caller received a *shorter map* rather than an error -
+/// and the result still carried <c>Success = true</c>. Nothing distinguished "this theme
+/// has nine colours" from "three reads failed", which matters because callers index these
+/// maps by name: a missing "Accent3" reads as a theme that has no Accent3.
+///
+/// Both catches also concealed a COM leak, because the release sat inside the guarded
+/// block and was skipped whenever the read threw.
+///
+/// These tests pin the complete key set, so a truncated read now fails loudly.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Design")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class DesignColorRoundTripTests : IClassFixture<TempDirectoryFixture>
+{
+    /// <summary>The twelve MsoThemeColorSchemeIndex roles GetColors enumerates.</summary>
+    private static readonly string[] ThemeColorRoles =
+    [
+        "Dark1", "Light1", "Dark2", "Light2",
+        "Accent1", "Accent2", "Accent3", "Accent4",
+        "Accent5", "Accent6", "Hyperlink", "FollowedHyperlink"
+    ];
+
+    private static readonly Regex HexColor = new("^#[0-9A-F]{6}$", RegexOptions.Compiled);
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly DesignCommands _designs = new();
+
+    public DesignColorRoundTripTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetColors_ReturnsEveryThemeColorRole()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: true);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+
+            var colors = _designs.GetColors(batch, designIndex: 1);
+            Assert.True(colors.Success, colors.ErrorMessage);
+
+            // Asserting the exact key set, not merely a count: a truncated walk that
+            // omitted Accent3 would still satisfy "at least eight colours".
+            Assert.Equal(
+                ThemeColorRoles.OrderBy(n => n).ToArray(),
+                colors.Colors.Keys.OrderBy(n => n).ToArray());
+
+            // Every value must be a real colour. An entry present but malformed would
+            // otherwise pass a key-only assertion.
+            Assert.All(colors.Colors, kvp =>
+                Assert.True(HexColor.IsMatch(kvp.Value), $"{kvp.Key} = '{kvp.Value}'"));
+
+            Assert.False(string.IsNullOrWhiteSpace(colors.DesignName));
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    /// <summary>
+    /// Documents a surprising truth rather than an aspiration: <c>Presentation.ColorSchemes</c>
+    /// is the pre-2007 API that themes replaced, and it is **empty** for a modern .pptx -
+    /// verified here both with and without slides. So <c>design list-color-schemes</c> can
+    /// never return data (GitHub #174), and its per-colour catch-all at
+    /// <c>DesignCommands.ListColorSchemes</c> is unreachable, which is why that one catch is
+    /// left in the #126 baseline: there is no way to prove removing it is safe.
+    ///
+    /// This is a characterisation test. If it ever fails, the operation started returning
+    /// something - which is what the follow-up issue asks for - and this test should be
+    /// replaced by real assertions on the roles, not deleted.
+    /// </summary>
+    [Fact]
+    public void ListColorSchemes_OnAModernPresentation_ReturnsNothing()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: true);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            new PptMcp.Core.Commands.Slide.SlideCommands()
+                .Create(batch, position: 0, layoutName: "Title Only");
+
+            var schemes = _designs.ListColorSchemes(batch);
+
+            // Success with nothing in it. That combination is the problem: a caller cannot
+            // tell "this deck has no colour schemes" from "this API no longer reports them".
+            Assert.True(schemes.Success, schemes.ErrorMessage);
+            Assert.Empty(schemes.ColorSchemes);
+
+            // The theme colours are the live equivalent, and they are populated - which is
+            // what makes the empty result above a reporting gap rather than an empty deck.
+            var colors = _designs.GetColors(batch, designIndex: 1);
+            Assert.True(colors.Success, colors.ErrorMessage);
+            Assert.NotEmpty(colors.Colors);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+}


### PR DESCRIPTION
Part of #126. Files #174 as a follow-up.

## A short palette, reported as a complete one

`DesignCommands.GetColors` builds its twelve-entry colour map one read at a time,
each read wrapped in a catch-all. A failed read simply **omitted its key**, so the
caller received a shorter map rather than an error — and the result still carried
`Success = true`.

That matters because callers index this map *by name*. A missing `Accent3` does
not read as "the read failed", it reads as **"this theme has no Accent3"**.

The catch also hid a **COM leak**: `ComUtilities.Release(ref colorItem!)` was the
last statement *inside* the `try`, so any failing read skipped it entirely — the
same shape as the `ShapeHelpers` leak fixed earlier on this issue. Restructured to
acquire before the `try` and release in a `finally`.

## Coverage first — `GetColors` had none

`DesignColorRoundTripTests` pins the **exact twelve-key set** rather than a count.
That distinction is the point: a walk that dropped one role would still satisfy
"at least eight colours". It also validates every value as `#RRGGBB`, so an entry
that is present but malformed cannot pass a key-only assertion.

Confirmed passing against the **unmodified** code before the catch was removed,
and still passing with it gone.

## What this PR deliberately does not touch

`ListColorSchemes` keeps its catch. The loop containing it is **unreachable**:
`Presentation.ColorSchemes` is the pre-2007 API that themes replaced, and it is
empty on a modern `.pptx` — verified here both with and without slides. There is
no way to prove removing that catch is safe, so it stays in the baseline rather
than being changed on faith.

The empty result is a defect in its own right, now filed as **#174**: the action
returns `Success = true` with nothing in it, which an LLM reads as "this deck has
no colour schemes" while `get-colors` returns a full twelve-role palette for the
same file. A characterisation test pins the current behaviour so that fixing #174
will be noticed here rather than silently diverging.

## Evidence

- `DesignColorRoundTripTests`: **2/2 passed**. The `GetColors` assertion passed
  before the change as well, which is what makes it a regression guard.
- `scripts/check-swallowed-catches.ps1` baseline lowered **12 → 11**.
- Local integration gate for `8ae9977`: **6/6 suites, 819 tests, 7.7m**.

## Rule 24 / Rule 27

No signature, CLI, MCP, or skill surface changed. `CHANGELOG.md` updated under
`## [Unreleased]` → `### Fixed`.
