### PR TITLE
fix: stop reporting a failed HasTextFrame read as no-text-frame (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A failed `HasTextFrame` read was reported as "this shape has no text frame"** (#126): `ShapeHelpers.ReadShapeInfo` and `PlaceholderCommands.List` both guarded that read with `catch { info.HasTextFrame = false; }`. That does not report a failure — it reports a fact, and a false one.
+  - `HasTextFrame` is a standard `Shape` property that answers `msoFalse` rather than throwing for a shape that genuinely has none, so the catch could only ever fire on a real failure — and the value it substituted was indistinguishable from that legitimate `msoFalse`. A caller checking `HasTextFrame` before writing text would silently skip a shape it could perfectly well write to, with the enclosing result still carrying `Success = true`.
+  - In `ShapeHelpers` a nested catch also discarded a failing `GetShapeText`, leaving `Text` null on a shape that had just reported `HasTextFrame = true` — a self-contradictory record. Removed with the outer one.
+  - Added `ShapeTextFrameReportingTests`, asserting **both directions**: a shape with text reports `true` plus its text, and a table shape reports `false` plus `HasTable = true`. Either assertion alone would pass against the bug — a catch that always answers `false` satisfies the negative case, and unconditional `true` satisfies the positive one.
+  - `scripts/swallowed-catches-baseline.txt` lowered from 9 to 7.
+
 - **`docprops set` wrote two properties to the wrong place, one of them silently** (#126): `DocumentPropertyCommands` addresses built-in properties by raw ordinal into the OLE built-in property set, and two of the seven ordinals were wrong.
   - `Company` should be **21**, not 15. Index 15 is *Number of words* — read-only and numeric — so every `--company` write threw, was swallowed, and `SetAll` still returned `Success = true, "Updated document properties"`. Reading it back gave `"0"`.
   - `Comments` should be **5**, not 6. Index 6 is *Template*. This one round-trips consistently with itself, so it produced no error at all: `--comments` quietly overwrote the presentation's Template property while the real Comments field stayed empty.

--- a/scripts/swallowed-catches-baseline.txt
+++ b/scripts/swallowed-catches-baseline.txt
@@ -2,8 +2,6 @@ src/PptMcp.Core/Commands/Background/BackgroundCommands.cs:39
 src/PptMcp.Core/Commands/Design/DesignCommands.cs:165
 src/PptMcp.Core/Commands/DocumentProperty/DocumentPropertyCommands.cs:162
 src/PptMcp.Core/Commands/Media/MediaCommands.cs:107
-src/PptMcp.Core/Commands/Placeholder/PlaceholderCommands.cs:49
-src/PptMcp.Core/Commands/Slide/ShapeHelpers.cs:43
 src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs:142
 src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs:73
 src/PptMcp.Core/Commands/Text/TextCommands.cs:925

--- a/src/PptMcp.Core/Commands/Placeholder/PlaceholderCommands.cs
+++ b/src/PptMcp.Core/Commands/Placeholder/PlaceholderCommands.cs
@@ -38,15 +38,16 @@ public class PlaceholderCommands : IPlaceholderCommands
                                 PlaceholderTypeName = GetPlaceholderTypeName(phType),
                             };
 
-                            try
+                            // HasTextFrame answers msoFalse rather than throwing for a
+                            // placeholder without a text frame, so a catch here could
+                            // only ever fire on a genuine failure - and it answered
+                            // "false", indistinguishable from that legitimate msoFalse
+                            // (#126).
+                            info.HasTextFrame = Convert.ToInt32(ph.HasTextFrame) != 0;
+                            if (info.HasTextFrame)
                             {
-                                info.HasTextFrame = Convert.ToInt32(ph.HasTextFrame) != 0;
-                                if (info.HasTextFrame)
-                                {
-                                    info.Text = ComUtilities.GetShapeText(ph);
-                                }
+                                info.Text = ComUtilities.GetShapeText(ph);
                             }
-                            catch { info.HasTextFrame = false; }
 
                             result.Placeholders.Add(info);
                         }

--- a/src/PptMcp.Core/Commands/Slide/ShapeHelpers.cs
+++ b/src/PptMcp.Core/Commands/Slide/ShapeHelpers.cs
@@ -31,16 +31,17 @@ internal static class ShapeHelpers
 
         try { info.AlternativeText = shape.AlternativeText?.ToString(); } catch { }
 
-        // HasTextFrame
-        try
+        // HasTextFrame is a standard Shape property present on every shape, and it
+        // answers msoFalse - it does not throw - for shapes without a text frame. A
+        // catch here could therefore only ever fire on a genuine failure, and it
+        // answered "false", which is indistinguishable from that legitimate msoFalse.
+        // A caller checking HasTextFrame before writing text would silently skip a
+        // shape it could perfectly well write to (#126).
+        info.HasTextFrame = Convert.ToInt32(shape.HasTextFrame) != 0; // msoTrue = -1
+        if (info.HasTextFrame)
         {
-            info.HasTextFrame = Convert.ToInt32(shape.HasTextFrame) != 0; // msoTrue = -1
-            if (info.HasTextFrame)
-            {
-                try { info.Text = ComUtilities.GetShapeText(shape); } catch { }
-            }
+            info.Text = ComUtilities.GetShapeText(shape);
         }
-        catch { info.HasTextFrame = false; }
 
         // HasTable
         try { info.HasTable = Convert.ToInt32(shape.HasTable) != 0; } catch { info.HasTable = false; }

--- a/tests/PptMcp.Core.Tests/Integration/ShapeTextFrameReportingTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/ShapeTextFrameReportingTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Placeholder;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Commands.SlideTable;
+using PptMcp.Core.Commands.Text;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Coverage for how <c>HasTextFrame</c> and <c>Text</c> are reported (GitHub #126).
+///
+/// Two places built a shape or placeholder description with the same guard:
+///
+/// <code>catch { info.HasTextFrame = false; }</code>
+///
+/// That does not report a failure — it reports a *fact*, and a false one. A caller that
+/// checks <c>HasTextFrame</c> before writing text will skip a shape that does have a text
+/// frame, and will do so silently, because the enclosing result still carries
+/// <c>Success = true</c>. The read that failed and the shape that genuinely has no text
+/// frame become indistinguishable.
+///
+/// <para><b>Both directions are asserted deliberately.</b></para>
+///
+/// Testing only that a textbox reports <c>true</c> would still pass if the code answered
+/// <c>true</c> unconditionally; testing only that a line reports <c>false</c> would pass
+/// against the very bug being removed, since the catch also answers <c>false</c>. Only the
+/// pair pins the behaviour.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Shape")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class ShapeTextFrameReportingTests : IClassFixture<TempDirectoryFixture>
+{
+    private const int MsoShapeRectangle = 1;
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly SlideCommands _slides = new();
+    private readonly ShapeCommands _shapes = new();
+    private readonly TextCommands _text = new();
+    private readonly SlideTableCommands _tables = new();
+    private readonly PlaceholderCommands _placeholders = new();
+
+    public ShapeTextFrameReportingTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void List_ReportsHasTextFrameAndTextForAShapeThatHasThem()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var added = _shapes.AddShape(batch, slideIndex: 1, autoShapeType: MsoShapeRectangle,
+                left: 100f, top: 100f, width: 200f, height: 80f);
+            Assert.True(added.Success, added.ErrorMessage);
+
+            var list = _shapes.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+            var shapeName = Assert.Single(list.Shapes).Name;
+
+            var setText = _text.SetText(batch, slideIndex: 1, shapeName: shapeName, text: "Frame content");
+            Assert.True(setText.Success, setText.ErrorMessage);
+
+            var reread = _shapes.List(batch, slideIndex: 1);
+            Assert.True(reread.Success, reread.ErrorMessage);
+            var shape = Assert.Single(reread.Shapes);
+
+            // The swallowed catch answered false here whenever the read failed, so a
+            // caller would have skipped a shape it could perfectly well write to.
+            Assert.True(shape.HasTextFrame);
+            Assert.Equal("Frame content", shape.Text);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void List_ReportsNoTextFrameForAShapeThatGenuinelyHasNone()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            // A table shape is the clean negative case: PowerPoint reports msoFalse for
+            // HasTextFrame and msoTrue for HasTable, so both neighbouring reads are
+            // covered by one shape.
+            var table = _tables.Create(batch, slideIndex: 1, rows: 2, columns: 2,
+                left: 50f, top: 50f, width: 300f, height: 100f);
+            Assert.True(table.Success, table.ErrorMessage);
+
+            var list = _shapes.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+            var shape = Assert.Single(list.Shapes);
+
+            // Removing the catch does not change this answer - which is the point. The
+            // catch was never needed for legitimate shapes; it only masked genuine
+            // read failures behind an identical-looking false.
+            Assert.False(shape.HasTextFrame);
+            Assert.True(shape.HasTable);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void PlaceholderList_ReportsHasTextFrameAndTextForATitlePlaceholder()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Title and Content");
+
+            var list = _placeholders.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+            Assert.NotEmpty(list.Placeholders);
+
+            var titlePlaceholder = list.Placeholders[0];
+            var setText = _text.SetText(batch, slideIndex: 1,
+                shapeName: titlePlaceholder.Name, text: "Placeholder content");
+            Assert.True(setText.Success, setText.ErrorMessage);
+
+            var reread = _placeholders.List(batch, slideIndex: 1);
+            Assert.True(reread.Success, reread.ErrorMessage);
+            var placeholder = reread.Placeholders[0];
+
+            Assert.True(placeholder.HasTextFrame);
+            Assert.Equal("Placeholder content", placeholder.Text);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void PlaceholderList_ReportsEveryPlaceholderOnTheSlide()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Title and Content");
+
+            var list = _placeholders.List(batch, slideIndex: 1);
+            Assert.True(list.Success, list.ErrorMessage);
+
+            // Every placeholder must carry a usable name and a resolved type name. A
+            // partially-populated entry is the shape of failure the catch allowed.
+            Assert.All(list.Placeholders, p =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(p.Name));
+                Assert.False(string.IsNullOrWhiteSpace(p.PlaceholderTypeName));
+            });
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ShapeHelpers.ReadShapeInfo` and `PlaceholderCommands.List` both guarded the `HasTextFrame` read the same way:

```csharp
catch { info.HasTextFrame = false; }
```

That does not report a failure. It reports a **fact**, and a false one.

`HasTextFrame` is a standard `Shape` property, and it answers `msoFalse` — it does not throw — for a shape that genuinely has no text frame. So the catch could only ever fire on a *real* failure, and the value it substituted was **indistinguishable from that legitimate `msoFalse`**.

The consequence is quiet and specific: a caller that checks `HasTextFrame` before writing text will skip a shape it could perfectly well write to, and the enclosing result still carries `Success = true`. Nothing anywhere reports that a read failed.

`ShapeHelpers` carried a second, nested catch that discarded a failing `GetShapeText`, leaving `Text` null on a shape that had *just* reported `HasTextFrame = true`. That record contradicts itself. Removed along with the outer one.

## Evidence

`ShapeTextFrameReportingTests` asserts **both directions**, deliberately:

| | Assertion |
|---|---|
| positive | a shape with text reports `HasTextFrame = true` **and** its text |
| negative | a table shape reports `HasTextFrame = false` **and** `HasTable = true` |

Either assertion on its own would pass against the bug. A catch that always answers `false` satisfies the negative case; code that answers `true` unconditionally satisfies the positive one. Only the pair pins the behaviour.

| | Result |
|---|---|
| before removal | 4 passed — this is latent-hazard removal, not an active defect |
| after removal | 4 passed |
| shape + slide-metadata suites | **16 passed** |

Local integration gate for `3a62acd`: **6 suites, 828 tests, 9.0m, PASSED.**

`scripts/swallowed-catches-baseline.txt` lowered from **9 to 7**.

## What remains on #126

Five sites, plus two deliberately retained:

- `BackgroundCommands.cs:39`, `MediaCommands.cs:107`, `SlideshowCommands.cs:73` and `:142`, `TextCommands.cs:925`
- **retained:** `DesignCommands.cs:165` (unreachable until #174) and the `SetCustom` existence probe in `DocumentPropertyCommands` (COM has no `TryGetItem`)
