### PR TITLE
fix: correct byte-reversed colour reads and clear the last removable catches (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Two colour read paths returned the colour byte-reversed** (#126): PowerPoint stores colours as `0x00BBGGRR`, so formatting the raw value with `:X6` yields `#BBGGRR`. `background get-info` and the run colours in `text get` both did exactly that, while five neighbouring reads open-coded the shift-and-mask correctly. The failure is quiet by construction — the output is a well-formed hex colour, just not the one that was set. Setting `#0B3D91` read back as `#913D0B`.
+  - Added `ComUtilities.FormatOleColorAsHex` and routed all seven sites through it, so the two spellings cannot diverge again.
+  - Found by writing the coverage #126 required, not by inspection.
+
+- **`background get-info` reported `FillType = "Unknown"` instead of failing** (#126): a catch-all around the fill read substituted a plausible-looking value under `Success = true`. Removed.
+
+- **`media get-info` answered questions about shapes that are not media** (#126): `Shape.MediaType` is only valid on a media shape and throws otherwise; the catch turned that into `MediaType = "Unknown"` with `Success = true`, so asking for media details about a rectangle produced a confident wrong answer. It now raises `InvalidOperationException` naming the shape, preserving the COM failure as the inner exception.
+
+- **Two slideshow existence probes were wider than the question they asked** (#126): `Presentation.SlideShowWindow` throws when no show is running and COM offers no `IsSlideShowRunning`, so the throw *is* the query — those catches are legitimate and are kept. But each spanned the work that followed it, so a genuine failure during `View.Exit()` or while reading `CurrentShowPosition` was reported back as "no slideshow was running" / "stopped at slide 0". Both are now narrowed to the acquisition alone.
+
 - **A failed `HasTextFrame` read was reported as "this shape has no text frame"** (#126): `ShapeHelpers.ReadShapeInfo` and `PlaceholderCommands.List` both guarded that read with `catch { info.HasTextFrame = false; }`. That does not report a failure — it reports a fact, and a false one.
   - `HasTextFrame` is a standard `Shape` property that answers `msoFalse` rather than throwing for a shape that genuinely has none, so the catch could only ever fire on a real failure — and the value it substituted was indistinguishable from that legitimate `msoFalse`. A caller checking `HasTextFrame` before writing text would silently skip a shape it could perfectly well write to, with the enclosing result still carrying `Success = true`.
   - In `ShapeHelpers` a nested catch also discarded a failing `GetShapeText`, leaving `Text` null on a shape that had just reported `HasTextFrame = true` — a self-contradictory record. Removed with the outer one.
   - Added `ShapeTextFrameReportingTests`, asserting **both directions**: a shape with text reports `true` plus its text, and a table shape reports `false` plus `HasTable = true`. Either assertion alone would pass against the bug — a catch that always answers `false` satisfies the negative case, and unconditional `true` satisfies the positive one.
-  - `scripts/swallowed-catches-baseline.txt` lowered from 9 to 7.
+  - `scripts/swallowed-catches-baseline.txt` lowered from 9 to 7, and then to **2** — the two that remain are deliberate: the `SetCustom` existence probe, and the unreachable `ListColorSchemes` catch (#174). Added `SwallowedCatchBehaviourTests`, the first behavioural coverage for background, slideshow and media; these features previously had only reflection tests asserting that their action enums were wide enough.
 
 - **`docprops set` wrote two properties to the wrong place, one of them silently** (#126): `DocumentPropertyCommands` addresses built-in properties by raw ordinal into the OLE built-in property set, and two of the seven ordinals were wrong.
   - `Company` should be **21**, not 15. Index 15 is *Number of words* — read-only and numeric — so every `--company` write threw, was swallowed, and `SetAll` still returned `Success = true, "Updated document properties"`. Reading it back gave `"0"`.

--- a/scripts/swallowed-catches-baseline.txt
+++ b/scripts/swallowed-catches-baseline.txt
@@ -1,7 +1,2 @@
-src/PptMcp.Core/Commands/Background/BackgroundCommands.cs:39
-src/PptMcp.Core/Commands/Design/DesignCommands.cs:165
+src/PptMcp.Core/Commands/Design/DesignCommands.cs:159
 src/PptMcp.Core/Commands/DocumentProperty/DocumentPropertyCommands.cs:162
-src/PptMcp.Core/Commands/Media/MediaCommands.cs:107
-src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs:142
-src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs:73
-src/PptMcp.Core/Commands/Text/TextCommands.cs:925

--- a/src/PptMcp.ComInterop/ComUtilities.cs
+++ b/src/PptMcp.ComInterop/ComUtilities.cs
@@ -349,6 +349,28 @@ public static class ComUtilities
     }
 
     /// <summary>
+    /// Formats an OLE colour value as <c>#RRGGBB</c>.
+    /// </summary>
+    /// <remarks>
+    /// PowerPoint stores colours as <c>0x00BBGGRR</c> - byte-reversed relative to the
+    /// familiar hex notation - so formatting the raw integer with <c>:X6</c> silently
+    /// produces <c>#BBGGRR</c>. That is not a crash and not an obviously wrong value:
+    /// it is a well-formed hex colour that simply is not the one the caller set.
+    /// Two read paths shipped that bug (GitHub #126) while five neighbouring ones
+    /// open-coded the same shift-and-mask correctly. This helper exists so the two
+    /// spellings cannot diverge again.
+    /// </remarks>
+    /// <param name="oleColor">An OLE colour value in PowerPoint's 0x00BBGGRR order.</param>
+    /// <returns>The colour as <c>#RRGGBB</c>.</returns>
+    public static string FormatOleColorAsHex(int oleColor)
+    {
+        int r = oleColor & 0xFF;
+        int g = (oleColor >> 8) & 0xFF;
+        int b = (oleColor >> 16) & 0xFF;
+        return $"#{r:X2}{g:X2}{b:X2}";
+    }
+
+    /// <summary>
     /// Reads a chart's title text without abandoning the intermediate
     /// <c>ChartTitle</c> proxy. See <see cref="GetSlide"/>.
     /// </summary>

--- a/src/PptMcp.Core/Commands/Background/BackgroundCommands.cs
+++ b/src/PptMcp.Core/Commands/Background/BackgroundCommands.cs
@@ -33,10 +33,10 @@ public class BackgroundCommands : IBackgroundCommands
 
                         if (fillType == 1) // msoFillSolid
                         {
-                            result.Color = $"#{ComUtilities.GetForeColorRgb(fill):X6}";
+                            result.Color = ComUtilities.FormatOleColorAsHex(
+                                ComUtilities.GetForeColorRgb(fill));
                         }
                     }
-                    catch { result.FillType = "Unknown"; }
                     finally
                     {
                         ComUtilities.Release(ref fill!);

--- a/src/PptMcp.Core/Commands/Design/DesignCommands.cs
+++ b/src/PptMcp.Core/Commands/Design/DesignCommands.cs
@@ -105,10 +105,7 @@ public partial class DesignCommands : IDesignCommands
                     {
                         int rgb = (int)colorItem.RGB;
                         // COM returns BGR, convert to #RRGGBB
-                        int r = rgb & 0xFF;
-                        int g = (rgb >> 8) & 0xFF;
-                        int b = (rgb >> 16) & 0xFF;
-                        colors[colorNames[i - 1]] = $"#{r:X2}{g:X2}{b:X2}";
+                        colors[colorNames[i - 1]] = ComUtilities.FormatOleColorAsHex(rgb);
                     }
                     finally
                     {
@@ -157,10 +154,7 @@ public partial class DesignCommands : IDesignCommands
                             try
                             {
                                 int rgb = (int)cs.Colors(c).RGB;
-                                int r = rgb & 0xFF;
-                                int g = (rgb >> 8) & 0xFF;
-                                int b = (rgb >> 16) & 0xFF;
-                                info.Colors[roleNames[c - 1]] = $"#{r:X2}{g:X2}{b:X2}";
+                                info.Colors[roleNames[c - 1]] = ComUtilities.FormatOleColorAsHex(rgb);
                             }
                             catch { }
                         }

--- a/src/PptMcp.Core/Commands/Media/MediaCommands.cs
+++ b/src/PptMcp.Core/Commands/Media/MediaCommands.cs
@@ -104,7 +104,15 @@ public class MediaCommands : IMediaCommands
                         _ => $"Unknown({mediaType})"
                     };
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    // shape.MediaType is only valid on a media shape. Absorbing the
+                    // failure produced MediaType = "Unknown" under Success = true, so
+                    // asking for media details about a rectangle returned a confident
+                    // wrong answer instead of an error (#126).
+                    throw new InvalidOperationException(
+                        $"Shape '{shapeName}' on slide {slideIndex} is not a media shape.", ex);
+                }
 
                 try { sourceFile = shape.LinkFormat?.SourceFullName?.ToString() ?? ""; } catch { }
 

--- a/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
+++ b/src/PptMcp.Core/Commands/Shape/ShapeCommands.cs
@@ -833,10 +833,7 @@ public class ShapeCommands : IShapeCommands
                 if (fillType == 1)
                 {
                     int rgb = ComUtilities.GetForeColorRgb(fill);
-                    int r = rgb & 0xFF;
-                    int g = (rgb >> 8) & 0xFF;
-                    int b = (rgb >> 16) & 0xFF;
-                    colorHex = $"#{r:X2}{g:X2}{b:X2}";
+                    colorHex = ComUtilities.FormatOleColorAsHex(rgb);
                 }
 
                 float transparency = Convert.ToSingle(fill.Transparency);
@@ -882,10 +879,7 @@ public class ShapeCommands : IShapeCommands
                 if (visible)
                 {
                     int rgb = ComUtilities.GetForeColorRgb(line);
-                    int r = rgb & 0xFF;
-                    int g = (rgb >> 8) & 0xFF;
-                    int b = (rgb >> 16) & 0xFF;
-                    colorHex = $"#{r:X2}{g:X2}{b:X2}";
+                    colorHex = ComUtilities.FormatOleColorAsHex(rgb);
                     weight = Convert.ToSingle(line.Weight);
                 }
 
@@ -1355,10 +1349,7 @@ public class ShapeCommands : IShapeCommands
                     float offsetY = Convert.ToSingle(shadow.OffsetY);
                     float blur = Convert.ToSingle(shadow.Blur);
                     int rgb = Convert.ToInt32(shadow.ForeColor.RGB);
-                    int r = rgb & 0xFF;
-                    int g = (rgb >> 8) & 0xFF;
-                    int b = (rgb >> 16) & 0xFF;
-                    string colorHex = $"#{r:X2}{g:X2}{b:X2}";
+                    string colorHex = ComUtilities.FormatOleColorAsHex(rgb);
                     message = $"Visible: true, OffsetX: {offsetX:F2}, OffsetY: {offsetY:F2}, Blur: {blur:F2}, Color: {colorHex}";
                 }
                 else

--- a/src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs
+++ b/src/PptMcp.Core/Commands/Slideshow/SlideshowCommands.cs
@@ -50,7 +50,26 @@ public class SlideshowCommands : ISlideshowCommands
             dynamic? window = null;
             try
             {
-                window = pres.SlideShowWindow;
+                // COM offers no IsSlideShowRunning, so acquiring SlideShowWindow and
+                // letting it throw *is* the query. The probe is deliberately narrowed to
+                // that one statement: the old catch spanned View.Exit() as well, so a
+                // genuine failure while stopping a running show was reported back as
+                // "No slideshow was running" (#126).
+                try
+                {
+                    window = pres.SlideShowWindow;
+                }
+                catch
+                {
+                    return new OperationResult
+                    {
+                        Success = true,
+                        Action = "stop",
+                        Message = "No slideshow was running",
+                        FilePath = ctx.PresentationPath
+                    };
+                }
+
                 dynamic? view = null;
                 try
                 {
@@ -67,17 +86,6 @@ public class SlideshowCommands : ISlideshowCommands
                     Success = true,
                     Action = "stop",
                     Message = "Stopped slideshow",
-                    FilePath = ctx.PresentationPath
-                };
-            }
-            catch
-            {
-                // No slideshow running
-                return new OperationResult
-                {
-                    Success = true,
-                    Action = "stop",
-                    Message = "No slideshow was running",
                     FilePath = ctx.PresentationPath
                 };
             }
@@ -123,9 +131,22 @@ public class SlideshowCommands : ISlideshowCommands
 
             bool isRunning = false;
             int currentSlide = 0;
+
+            // Same narrowed existence probe as EndShow: only the acquisition may throw
+            // to mean "not running". The old catch also spanned the CurrentShowPosition
+            // read, so a failure there reported a stopped show at slide 0 (#126).
+            dynamic? window = null;
             try
             {
-                dynamic window = pres.SlideShowWindow;
+                window = pres.SlideShowWindow;
+            }
+            catch
+            {
+                window = null;
+            }
+
+            if (window != null)
+            {
                 dynamic? view = null;
                 try
                 {
@@ -138,10 +159,6 @@ public class SlideshowCommands : ISlideshowCommands
                     if (view != null) ComUtilities.Release(ref view!);
                     ComUtilities.Release(ref window!);
                 }
-            }
-            catch
-            {
-                // No slideshow running
             }
 
             return new SlideshowInfoResult

--- a/src/PptMcp.Core/Commands/Text/TextCommands.cs
+++ b/src/PptMcp.Core/Commands/Text/TextCommands.cs
@@ -919,10 +919,9 @@ public class TextCommands : ITextCommands
                                     try
                                     {
                                         runColor = runFont.Color;
-                                        int rgb = Convert.ToInt32(runColor.RGB);
-                                        runInfo.Color = $"#{rgb:X6}";
+                                        runInfo.Color = ComUtilities.FormatOleColorAsHex(
+                                            Convert.ToInt32(runColor.RGB));
                                     }
-                                    catch { }
                                     finally
                                     {
                                         ComUtilities.Release(ref runColor!);

--- a/tests/PptMcp.Core.Tests/Integration/SwallowedCatchBehaviourTests.cs
+++ b/tests/PptMcp.Core.Tests/Integration/SwallowedCatchBehaviourTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Torsten Mahr. All rights reserved.
+// Licensed under the MIT License.
+
+using PptMcp.ComInterop.Session;
+using PptMcp.Core.Commands.Background;
+using PptMcp.Core.Commands.Media;
+using PptMcp.Core.Commands.Shape;
+using PptMcp.Core.Commands.Slide;
+using PptMcp.Core.Commands.Slideshow;
+using PptMcp.Core.Commands.Text;
+using PptMcp.Core.Tests.Helpers;
+using Xunit;
+
+namespace PptMcp.Core.Tests.Integration;
+
+/// <summary>
+/// Coverage for the last four swallowing catch blocks outside the text formatter
+/// (GitHub #126). Each one produced a plausible wrong answer under a
+/// <c>Success = true</c> result, and each had no behavioural test - only reflection
+/// tests asserting that the action enums were wide enough.
+///
+/// <para><b>Two of these catches are genuine existence probes and are kept.</b></para>
+///
+/// <c>Presentation.SlideShowWindow</c> throws when no slideshow is running; COM offers
+/// no <c>IsSlideShowRunning</c>, so the throw <i>is</i> the query. What was wrong was
+/// the catch's <i>width</i>: it wrapped the probe together with the work that follows
+/// it, so a failure during <c>View.Exit()</c> or while reading
+/// <c>CurrentShowPosition</c> was absorbed into "no slideshow was running". The probes
+/// are now narrowed to the acquisition alone, and these tests pin the not-running
+/// answers that the probes must keep producing.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Slow")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "Background")]
+[Trait("RequiresPowerPoint", "true")]
+public sealed class SwallowedCatchBehaviourTests : IClassFixture<TempDirectoryFixture>
+{
+    private const int MsoShapeRectangle = 1;
+
+    private readonly TempDirectoryFixture _fixture;
+    private readonly SlideCommands _slides = new();
+    private readonly ShapeCommands _shapes = new();
+    private readonly BackgroundCommands _background = new();
+    private readonly SlideshowCommands _slideshow = new();
+    private readonly MediaCommands _media = new();
+    private readonly TextCommands _text = new();
+
+    public SwallowedCatchBehaviourTests(TempDirectoryFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void BackgroundGetInfo_ReportsTheColourThatWasSet_NotUnknown()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var set = _background.SetColor(batch, slideIndex: 1, colorHex: "#0B3D91");
+            Assert.True(set.Success, set.ErrorMessage);
+
+            var info = _background.GetInfo(batch, slideIndex: 1);
+            Assert.True(info.Success, info.ErrorMessage);
+
+            // The removed catch answered FillType = "Unknown" on any read failure, while
+            // still reporting Success = true. "Unknown" is a plausible-looking value, so
+            // nothing downstream could tell it apart from a real answer.
+            Assert.False(info.FollowMasterBackground);
+            Assert.Equal("Solid", info.FillType);
+            Assert.Equal("#0B3D91", info.Color);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void BackgroundGetInfo_ReportsMasterWhenTheSlideFollowsIt()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var info = _background.GetInfo(batch, slideIndex: 1);
+            Assert.True(info.Success, info.ErrorMessage);
+
+            // The other direction: a fresh slide inherits from the master, and that path
+            // never enters the guarded block at all. Asserting both keeps "Solid" from
+            // being satisfied by a constant.
+            Assert.True(info.FollowMasterBackground);
+            Assert.Equal("Master", info.FillType);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void SlideshowGetStatus_ReportsNotRunningWhenNoShowIsActive()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var status = _slideshow.GetStatus(batch);
+            Assert.True(status.Success, status.ErrorMessage);
+
+            // This is the answer the narrowed existence probe must keep producing.
+            Assert.False(status.IsRunning);
+            Assert.Equal(0, status.CurrentSlide);
+
+            // TotalSlides is read outside the probe entirely, so it must be real. A probe
+            // widened back over the whole method would leave this at 0.
+            Assert.True(status.TotalSlides > 0, $"expected slides, got {status.TotalSlides}");
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void SlideshowEndShow_SucceedsWhenNoShowIsRunning()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var stop = _slideshow.EndShow(batch);
+
+            // Stopping a show that is not running is not an error - it is the requested
+            // end state. The narrowed probe preserves that.
+            Assert.True(stop.Success, stop.ErrorMessage);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void MediaGetInfo_FailsOnAShapeThatIsNotMedia()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var added = _shapes.AddShape(batch, slideIndex: 1, autoShapeType: MsoShapeRectangle,
+                left: 100f, top: 100f, width: 200f, height: 80f);
+            Assert.True(added.Success, added.ErrorMessage);
+
+            var shapeName = Assert.Single(_shapes.List(batch, slideIndex: 1).Shapes).Name;
+
+            // shape.MediaType is only valid on a media shape. The removed catch turned
+            // that failure into MediaType = "Unknown" under Success = true, so asking for
+            // media details about a rectangle produced a confident, wrong answer instead
+            // of an error.
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => _media.GetInfo(batch, slideIndex: 1, shapeName: shapeName));
+
+            // The message must name the shape, so the caller can act on it. The original
+            // COM failure is preserved as the inner exception.
+            Assert.Contains(shapeName, ex.Message);
+            Assert.NotNull(ex.InnerException);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+
+    [Fact]
+    public void GetText_ReportsRunColourInRgbOrderNotPowerPointsByteOrder()
+    {
+        var testFile = _fixture.CreateTestFile();
+
+        using var manager = new SessionManager();
+        var sessionId = manager.CreateSession(testFile, show: false);
+
+        try
+        {
+            var batch = manager.GetSession(sessionId)!;
+            _slides.Create(batch, position: 0, layoutName: "Blank");
+
+            var added = _shapes.AddShape(batch, slideIndex: 1, autoShapeType: MsoShapeRectangle,
+                left: 100f, top: 100f, width: 240f, height: 90f);
+            Assert.True(added.Success, added.ErrorMessage);
+
+            var shapeName = Assert.Single(_shapes.List(batch, slideIndex: 1).Shapes).Name;
+
+            Assert.True(_text.SetText(batch, 1, shapeName, "Coloured run").Success);
+            var format = _text.Format(batch, slideIndex: 1, shapeName: shapeName,
+                fontName: null, fontSize: null, bold: null, italic: null,
+                color: "#0B3D91", alignment: null, verticalAlignment: null);
+            Assert.True(format.Success, format.ErrorMessage);
+
+            var read = _text.GetText(batch, slideIndex: 1, shapeName: shapeName);
+            Assert.True(read.Success, read.ErrorMessage);
+
+            var run = read.Paragraphs.SelectMany(p => p.Runs).First();
+
+            // A deliberately asymmetric colour: #0B3D91 byte-reversed is #913D0B, so a
+            // read path that formats PowerPoint's raw 0x00BBGGRR value straight to hex
+            // produces a well-formed but wrong answer rather than an error.
+            Assert.Equal("#0B3D91", run.Color);
+        }
+        finally
+        {
+            manager.CloseSession(sessionId, save: false);
+        }
+    }
+}


### PR DESCRIPTION
## The bug the coverage found

Writing the tests #126 asks for turned up a **second defect, unrelated to the catches**.

PowerPoint stores colours as `0x00BBGGRR`. Formatting that raw value with `:X6` therefore yields `#BBGGRR`. Two read paths did exactly that:

| Site | |
|---|---|
| `BackgroundCommands.cs:36` | `background get-info` |
| `TextCommands.cs:923` | run colours in `text get` |

Five neighbouring reads open-coded the shift-and-mask correctly, so this was drift between two spellings of the same idea rather than a misunderstanding.

**Setting `#0B3D91` read back as `#913D0B`.**

The failure is quiet by construction: the output is a well-formed hex colour, just not the one that was set. Nothing downstream can tell it apart from a real answer.

Added `ComUtilities.FormatOleColorAsHex` and routed **all seven** sites through it, so the two spellings cannot diverge again.

## Swallowing catches

**`background get-info`** substituted `FillType = "Unknown"` on a failed fill read while still reporting `Success = true`. Removed.

**`media get-info`** absorbed the failure of `Shape.MediaType`, which is valid only on a media shape. Asking for media details about a rectangle returned `MediaType = "Unknown"` with `Success = true` — a confident, wrong answer. It now raises `InvalidOperationException` naming the shape, with the COM failure preserved as the inner exception.

**The two slideshow catches are legitimate and are kept.** `Presentation.SlideShowWindow` throws when no show is running, and COM offers no `IsSlideShowRunning`, so the throw *is* the query. What was wrong was their **width**: each spanned the work that followed it, so a genuine failure during `View.Exit()` or while reading `CurrentShowPosition` came back as *"no slideshow was running"* or *"stopped at slide 0"*. Both are now narrowed to the acquisition alone — the same treatment applied to the `SetCustom` probe in #176.

## Evidence

`SwallowedCatchBehaviourTests` is the first **behavioural** coverage for background, slideshow and media. Those features previously had only reflection tests asserting that their action enums were wide enough.

| | Result |
|---|---|
| before fix | **2 failed**, 3 passed |
| after fix | **6 passed** |
| colour + text + shape + design suites | **15 passed** |

The background test asserts both directions — a slide with an explicit colour, and a fresh slide inheriting from the master — so `"Solid"` cannot be satisfied by a constant.

Local integration gate for `c60854a`: **6 suites, 834 tests, 18.3m, PASSED** (full run, no suite reused, since `ComUtilities` changed).

## Where #126 stands

`scripts/swallowed-catches-baseline.txt`: **18 → 2** over this series.

The two that remain are deliberate, and both are documented in code:

- the `SetCustom` existence probe — COM has no `TryGetItem`
- `DesignCommands.cs:159` — unreachable until #174 is resolved; untestable code should not be "fixed" on faith
