### PR TITLE
fix: stop the timeout suite stranding an un-reclaimable PowerPoint (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`PptBatchTimeoutTests` could strand a PowerPoint process that nothing could then reclaim** (#172): a survivor from a force-killing test is inherited by the next session, because PowerPoint is single-instance. That session reports `_ownsPowerPointProcess = false`, so if it also times out, teardown declines to force-kill (correctly — the process might be the user's, #160), its STA thread stays wedged, STA cleanup never runs, and `_foreignPresentationCount` is therefore never computed. The terminate-on-disposal check is `_ownsPowerPointProcess || _foreignPresentationCount == 0`, which is then false on both sides. The instance becomes permanently un-terminable and every later session attaches to it.
+  - Production behaviour is unchanged and deliberate: an unknown foreign-presentation count means the user may have unsaved work open, and the safe answer is to leave the process alone.
+  - The fix is in the suite that creates the survivors. `SuiteOwnedPowerPoint` snapshots the running POWERPNT process IDs before the suite's first test; anything appearing afterwards is the suite's, and anything in the snapshot — the user's own instance included — is left strictly alone. `PptBatchTimeoutTests` now reclaims its own survivors and then **asserts there were none**, so the leak is surfaced rather than silently absorbed.
+  - Reclaim runs before the finalizer drain: ending a wedged process first turns an RCW finalise that would block for COM's full call timeout into a fast RPC failure.
+
 - **Two colour read paths returned the colour byte-reversed** (#126): PowerPoint stores colours as `0x00BBGGRR`, so formatting the raw value with `:X6` yields `#BBGGRR`. `background get-info` and the run colours in `text get` both did exactly that, while five neighbouring reads open-coded the shift-and-mask correctly. The failure is quiet by construction — the output is a well-formed hex colour, just not the one that was set. Setting `#0B3D91` read back as `#913D0B`.
   - Added `ComUtilities.FormatOleColorAsHex` and routed all seven sites through it, so the two spellings cannot diverge again.
   - Found by writing the coverage #126 required, not by inspection.

--- a/tests/PptMcp.ComInterop.Tests/Integration/Session/PptBatchTimeoutTests.cs
+++ b/tests/PptMcp.ComInterop.Tests/Integration/Session/PptBatchTimeoutTests.cs
@@ -31,6 +31,14 @@ public class PptBatchTimeoutTests : IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;
     private static string? _staticTestFile;
+
+    /// <summary>
+    /// Snapshot of the POWERPNT processes that existed before this suite's first test, taken once
+    /// for the whole class. Anything running afterwards that is not in it appeared while this
+    /// suite was force-killing PowerPoint, and is this suite's to reclaim (issue #172).
+    /// </summary>
+    private static SuiteOwnedPowerPoint? _powerPointGuard;
+
     private string? _testFileCopy;
 
     public PptBatchTimeoutTests(ITestOutputHelper output)
@@ -40,6 +48,10 @@ public class PptBatchTimeoutTests : IAsyncLifetime
 
     public Task InitializeAsync()
     {
+        // Taken before the first test, so a PowerPoint the machine already had open - the user's
+        // own, or one an earlier class left behind - is recorded as not ours and stays untouched.
+        _powerPointGuard ??= new SuiteOwnedPowerPoint();
+
         if (_staticTestFile == null)
         {
             var testFolder = Path.Join(AppContext.BaseDirectory, "Integration", "Session", "TestFiles");
@@ -59,6 +71,13 @@ public class PptBatchTimeoutTests : IAsyncLifetime
 
     public Task DisposeAsync()
     {
+        // Reclaim first. A survivor holds this test's file open, and it is a live PowerPoint this
+        // suite wedged - finalising an RCW that points at a live-but-wedged endpoint blocks for
+        // COM's full call timeout. Ending the process first releases the handle and turns that
+        // wait into a fast RPC failure, so the drain below measures abandoned proxies rather than
+        // a hung server.
+        var reclaimed = _powerPointGuard!.Reclaim();
+
         if (_testFileCopy != null && File.Exists(_testFileCopy))
         {
 #pragma warning disable CA1031 // Intentional: best-effort test cleanup
@@ -70,6 +89,17 @@ public class PptBatchTimeoutTests : IAsyncLifetime
         // See AbandonedComProxies for why this is per test rather than per class.
         var drained = AbandonedComProxies.Drain();
         _output.WriteLine($"Drained abandoned COM proxies in {drained.TotalSeconds:F1}s.");
+
+        // Cleaning up is not the same as being clean. A survivor means session teardown failed to
+        // end a process it started, and the next session would have attached to it instead of
+        // starting its own - at which point it is no longer terminable by anything, because
+        // teardown correctly refuses to force-kill a process it did not start (issue #172).
+        Assert.True(
+            reclaimed.Count == 0,
+            $"This suite left {reclaimed.Count} PowerPoint process(es) running: " +
+            $"{string.Join(", ", reclaimed)}. They have been terminated so the rest of the run is " +
+            "unaffected, but session teardown should have ended them. A survivor is inherited by " +
+            "every later session and cannot be reclaimed by any of them.");
 
         return Task.CompletedTask;
     }

--- a/tests/PptMcp.ComInterop.Tests/Integration/Session/SuiteOwnedPowerPoint.cs
+++ b/tests/PptMcp.ComInterop.Tests/Integration/Session/SuiteOwnedPowerPoint.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+
+namespace PptMcp.ComInterop.Tests.Integration.Session;
+
+/// <summary>
+/// Identifies the POWERPNT processes a suite is responsible for, and reclaims them.
+///
+/// <para><b>Why this exists.</b> A session that force-kills PowerPoint can leave a survivor,
+/// and a survivor is not merely untidy - it is permanent. The next session attaches to it,
+/// because PowerPoint is single-instance, and therefore reports <c>_ownsPowerPointProcess =
+/// false</c>. If that session then times out, teardown declines to force-kill (correctly: the
+/// process might be the user's, issue #160), so its STA thread stays wedged, so STA cleanup
+/// never runs, so <c>_foreignPresentationCount</c> is never computed and stays null. The
+/// terminate-on-disposal check is <c>_ownsPowerPointProcess || _foreignPresentationCount == 0</c>,
+/// which is then false on both sides. Every later session inherits the same instance and makes
+/// the same refusal (issue #172).</para>
+///
+/// <para><b>Why the fix is here and not in PptBatch.</b> That refusal is right in production.
+/// An unknown foreign-presentation count means "the user may have unsaved work open", and the
+/// safe answer to that is to leave the process alone. What is wrong is a test suite that
+/// force-kills PowerPoint by design leaving a survivor behind for its successors to inherit.</para>
+///
+/// <para><b>The responsibility rule.</b> Snapshot the running POWERPNT process IDs before the
+/// suite's first test. Anything running afterwards that is not in that snapshot appeared while
+/// the suite was running and is the suite's to reclaim. Anything in the snapshot is left strictly
+/// alone - it may be the user's own PowerPoint, and it is the same signal
+/// <c>PptBatch</c> itself uses to decide ownership.</para>
+///
+/// <para>This asserts observable state rather than waiting out a delay, so it cannot decay into
+/// a slower flake the way a sleep would.</para>
+/// </summary>
+internal sealed class SuiteOwnedPowerPoint
+{
+    private readonly HashSet<int> _preExisting;
+
+    /// <summary>
+    /// Snapshots the POWERPNT processes running right now. Every one of them is off limits.
+    /// </summary>
+    public SuiteOwnedPowerPoint()
+        : this(RunningPowerPointProcessIds())
+    {
+    }
+
+    /// <summary>
+    /// Uses an explicit snapshot. Tests use this to place a process they created on either side
+    /// of the responsibility boundary without depending on what was running on the machine.
+    /// </summary>
+    public SuiteOwnedPowerPoint(IEnumerable<int> preExisting)
+    {
+        _preExisting = new HashSet<int>(preExisting);
+    }
+
+    /// <summary>
+    /// POWERPNT processes running now that were not running when the snapshot was taken.
+    /// </summary>
+    public IReadOnlyList<int> Survivors() =>
+        RunningPowerPointProcessIds().Where(pid => !_preExisting.Contains(pid)).ToList();
+
+    /// <summary>
+    /// Terminates every survivor and returns the process IDs that were terminated, so a caller
+    /// can report what it cleaned up rather than cleaning up silently. An empty result means the
+    /// suite left nothing behind.
+    /// </summary>
+    public IReadOnlyList<int> Reclaim()
+    {
+        var reclaimed = new List<int>();
+
+        foreach (var pid in Survivors())
+        {
+            try
+            {
+                using var process = Process.GetProcessById(pid);
+                if (process.HasExited)
+                {
+                    continue;
+                }
+
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(5000);
+                reclaimed.Add(pid);
+            }
+            catch (ArgumentException)
+            {
+                // Exited and was reaped between the enumeration and the kill.
+            }
+        }
+
+        return reclaimed;
+    }
+
+    private static List<int> RunningPowerPointProcessIds()
+    {
+        var pids = new List<int>();
+
+        foreach (var process in Process.GetProcessesByName("POWERPNT"))
+        {
+            try
+            {
+                pids.Add(process.Id);
+            }
+            finally
+            {
+                process.Dispose();
+            }
+        }
+
+        return pids;
+    }
+}

--- a/tests/PptMcp.ComInterop.Tests/Integration/Session/SuiteOwnedPowerPointTests.cs
+++ b/tests/PptMcp.ComInterop.Tests/Integration/Session/SuiteOwnedPowerPointTests.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics;
+using PptMcp.ComInterop.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PptMcp.ComInterop.Tests.Integration.Session;
+
+/// <summary>
+/// Verifies the responsibility rule <see cref="SuiteOwnedPowerPoint"/> applies before it is
+/// trusted to clean up after <see cref="PptBatchTimeoutTests"/> (issue #172).
+///
+/// <para>Both directions are asserted deliberately. A guard that reclaims everything would
+/// terminate the user's own PowerPoint, which is the hazard issue #160 exists to prevent; a
+/// guard that reclaims nothing would leave the survivor that issue #172 is about. Neither
+/// failure is visible from the passing direction alone.</para>
+///
+/// <para>Each test uses a genuine POWERPNT process started by a real session, and injects the
+/// snapshot so the process sits on a known side of the boundary. That keeps the outcome
+/// independent of whatever PowerPoint the machine happens to have open, and guarantees the
+/// guard is never asked about a process this test did not create.</para>
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Speed", "Medium")]
+[Trait("Layer", "ComInterop")]
+[Trait("Feature", "PptBatch")]
+[Trait("RequiresPowerPoint", "true")]
+[Collection("Sequential")]
+public class SuiteOwnedPowerPointTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _testFile;
+
+    public SuiteOwnedPowerPointTests(ITestOutputHelper output)
+    {
+        _output = output;
+
+        var template = Path.Combine(
+            AppContext.BaseDirectory, "Integration", "Session", "TestFiles", "batch-test-static.pptx");
+
+        _testFile = Path.Combine(Path.GetTempPath(), $"suite-owned-ppt-{Guid.NewGuid():N}.pptx");
+        File.Copy(template, _testFile);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFile))
+        {
+            try
+            {
+                File.Delete(_testFile);
+            }
+            catch (IOException)
+            {
+                // Best effort - a stuck PowerPoint may still hold the handle.
+            }
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// A PowerPoint that appeared after the snapshot is the suite's, and must be terminated.
+    /// This is the survivor that would otherwise be inherited by every later session.
+    /// </summary>
+    [Fact]
+    public void Reclaim_TerminatesPowerPointThatAppearedAfterTheSnapshot()
+    {
+        var batch = PptSession.BeginBatch(_testFile);
+        int pid = RequireProcessId(batch);
+
+        // Snapshot excluding this process, so it stands as one that appeared while the suite ran.
+        var guard = new SuiteOwnedPowerPoint(RunningPowerPointPids().Where(p => p != pid));
+
+        Assert.Contains(pid, guard.Survivors());
+
+        var reclaimed = guard.Reclaim();
+        _output.WriteLine($"Reclaimed: {string.Join(", ", reclaimed)}");
+
+        Assert.Contains(pid, reclaimed);
+        Assert.True(
+            HasExited(pid),
+            $"PowerPoint process {pid} appeared while the suite was running, so the suite is " +
+            "responsible for it. Leaving it alive strands an instance that every later session " +
+            "attaches to and then declines to clean up.");
+
+        Assert.DoesNotContain(pid, guard.Survivors());
+
+        batch.Dispose();
+    }
+
+    /// <summary>
+    /// A PowerPoint that was already running when the snapshot was taken is not the suite's, and
+    /// must survive. It may be the user's own, holding unsaved work in decks we never opened.
+    /// </summary>
+    [Fact]
+    public void Reclaim_LeavesPowerPointThatWasRunningBeforeTheSnapshot()
+    {
+        var batch = PptSession.BeginBatch(_testFile);
+        int pid = RequireProcessId(batch);
+
+        try
+        {
+            // Snapshot including this process, so it stands as one the user already had open.
+            var guard = new SuiteOwnedPowerPoint(RunningPowerPointPids());
+
+            Assert.DoesNotContain(pid, guard.Survivors());
+
+            var reclaimed = guard.Reclaim();
+            _output.WriteLine($"Reclaimed: [{string.Join(", ", reclaimed)}]");
+
+            Assert.DoesNotContain(pid, reclaimed);
+            Assert.False(
+                HasExited(pid),
+                $"PowerPoint process {pid} was already running when the snapshot was taken, so it " +
+                "is not the suite's to terminate. Killing it would discard the user's unsaved work.");
+        }
+        finally
+        {
+            batch.Dispose();
+        }
+    }
+
+    private static int RequireProcessId(IPptBatch batch)
+    {
+        int? pid = batch.PowerPointProcessId;
+
+        Assert.True(
+            pid.HasValue,
+            "The session did not capture a PowerPoint process ID, so this test cannot place a known " +
+            "process on either side of the responsibility boundary.");
+
+        return pid!.Value;
+    }
+
+    private static List<int> RunningPowerPointPids()
+    {
+        var pids = new List<int>();
+
+        foreach (var process in Process.GetProcessesByName("POWERPNT"))
+        {
+            try
+            {
+                pids.Add(process.Id);
+            }
+            finally
+            {
+                process.Dispose();
+            }
+        }
+
+        return pids;
+    }
+
+    private static bool HasExited(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return true; // Exited and was reaped.
+        }
+    }
+}


### PR DESCRIPTION
## The mechanism

A POWERPNT left behind by a force-killing test is not merely untidy. It is **permanent**, and the chain is worth stating exactly.

PowerPoint is single-instance, so the next session **attaches** to the survivor rather than starting its own, and therefore reports `_ownsPowerPointProcess = false`. If that session also times out:

1. `Dispose` declines to force-kill — **correctly**, because the process might be the user's (#160).
2. Its STA thread therefore stays wedged.
3. So STA cleanup never runs.
4. So `_foreignPresentationCount` — which is assigned *only* in STA cleanup — stays `null`.

The terminate-on-disposal check is:

```csharp
_ownsPowerPointProcess || _foreignPresentationCount == 0
```

`false || (null == 0)` → **false**. Both refusals fire. Nothing can reclaim the instance, and every later session inherits it and makes the same refusal.

That is the cascade the issue describes as "the next session attaches to it instead of starting its own".

## Production behaviour is unchanged, deliberately

An unknown foreign-presentation count means *the user may have unsaved work open*, and the safe answer to that is to leave the process alone. Making teardown more aggressive here would reopen #160.

What is wrong is narrower, and it is exactly what the issue says: **a suite that force-kills PowerPoint by design should not leave a survivor for its successors to inherit.**

## The fix

`SuiteOwnedPowerPoint` applies the same ownership signal `PptBatch` already uses — snapshot the running POWERPNT process IDs before the suite's first test, and treat anything appearing afterwards as the suite's. Anything **in** the snapshot is left strictly alone: the user's own instance, or one an earlier class left behind.

`PptBatchTimeoutTests` now reclaims its survivors **and then asserts there were none**. The cleanup protects the rest of the run; the assertion is what stops the leak being silently absorbed. Cleaning up is not the same as being clean.

Reclaim runs **before** the finalizer drain, not after. Ending a wedged process first turns an RCW finalise that would otherwise block for COM's full call timeout into a fast RPC failure — so the drain measures abandoned proxies rather than a hung server.

This is observable state throughout, never a delay, consistent with how #161 was closed.

## Both directions

A guard that reclaimed everything would kill the user's PowerPoint. One that reclaimed nothing would leave the survivor. **Neither failure is visible from the passing direction alone**, so both are asserted.

Each test uses a genuine POWERPNT started by a real session, with the snapshot *injected* so the process sits on a known side of the boundary. That keeps the result independent of whatever the machine happens to have open, and guarantees the guard is never asked about a process the test did not create.

## Evidence

| Suite | Result |
|---|---|
| `SuiteOwnedPowerPointTests` | **2 passed** (8s) |
| `PptBatchTimeoutTests` | **6 passed** (2.9m) |
| ComInterop `Integration.Session`, all | **68 passed** (7m20s) |

Local integration gate for `a14c826`: **6 suites, 836 tests, 9.3m, PASSED** (`cominterop-full` re-run, 101 tests).

The guard reclaimed nothing across these runs, which is consistent with the leak being intermittent — it was observed once, while diagnosing #161, and not reproduced on the following run. Its two halves are each proven independently: `Reclaim()` returns a non-empty list for a genuine survivor, and the suite asserts that list is empty.
